### PR TITLE
[#7] 장바구니 기능 구현

### DIFF
--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -2,6 +2,7 @@ package ksh.deliveryhub.cart.api;
 
 import jakarta.validation.Valid;
 import ksh.deliveryhub.cart.dto.request.CartMenuCreateRequestDto;
+import ksh.deliveryhub.cart.dto.request.CartMenuUpdateRequestDto;
 import ksh.deliveryhub.cart.dto.response.CartMenuResponseDto;
 import ksh.deliveryhub.cart.dto.response.CartResponseDto;
 import ksh.deliveryhub.cart.facade.CartFacade;
@@ -44,6 +45,20 @@ public class CartController {
         @Valid @RequestBody CartMenuCreateRequestDto request
     ) {
         cartFacade.addMenuToCart(userId, request.toModel());
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .build();
+    }
+
+    @PostMapping("/carts/{cartId}/menus/{cartMenuId}")
+    public ResponseEntity<SuccessResponseDto> changeMenuQuantity(
+        @PathVariable("cartId") long cartId,
+        @PathVariable("cartMenuId") long cartMenuId,
+        @RequestParam("userId") long userId,
+        @Valid @RequestBody CartMenuUpdateRequestDto request
+    ) {
+        cartFacade.addMenuToCart(userId, request.toModel(cartMenuId));
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -1,0 +1,39 @@
+package ksh.deliveryhub.cart.api;
+
+import ksh.deliveryhub.cart.dto.response.CartMenuResponseDto;
+import ksh.deliveryhub.cart.dto.response.CartResponseDto;
+import ksh.deliveryhub.cart.facade.CartFacade;
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartFacade cartFacade;
+
+    @GetMapping("/carts/{cartId}/menus")
+    public ResponseEntity getUserCart(
+        @PathVariable("cartId") long cartId,
+        @RequestParam("userId") long userId
+    ) {
+        List<CartMenuResponseDto> cartMenuResponseDtos = cartFacade.getUserCartMenuDetails(userId).stream()
+            .map(CartMenuResponseDto::from)
+            .toList();
+
+        CartResponseDto cartResponseDto = CartResponseDto.of(cartMenuResponseDtos);
+        SuccessResponseDto<CartResponseDto> response = SuccessResponseDto.of(cartResponseDto);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(response);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -20,7 +20,7 @@ public class CartController {
 
     private final CartFacade cartFacade;
 
-    @GetMapping("/carts/menus")
+    @GetMapping("/carts")
     public ResponseEntity<SuccessResponseDto> getUserCart(
         @RequestParam("userId") long userId
     ) {
@@ -61,7 +61,7 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/carts}")
+    @PostMapping("/carts")
     public ResponseEntity<SuccessResponseDto> clearCart(
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuUpdateRequestDto request

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -2,7 +2,6 @@ package ksh.deliveryhub.cart.api;
 
 import jakarta.validation.Valid;
 import ksh.deliveryhub.cart.dto.request.CartMenuCreateRequestDto;
-import ksh.deliveryhub.cart.dto.request.CartMenuUpdateRequestDto;
 import ksh.deliveryhub.cart.dto.response.CartMenuResponseDto;
 import ksh.deliveryhub.cart.dto.response.CartResponseDto;
 import ksh.deliveryhub.cart.facade.CartFacade;
@@ -48,19 +47,6 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/users/{userId}/carts/menus/{cartMenuId}")
-    public ResponseEntity<SuccessResponseDto> changeMenuQuantity(
-        @PathVariable("userId") long userId,
-        @PathVariable("cartMenuId") long cartMenuId,
-        @Valid @RequestBody CartMenuUpdateRequestDto request
-    ) {
-        cartFacade.changeQuantity(userId, request.toModel(cartMenuId));
-
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .build();
-    }
-
     @PostMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> clearCart(
         @PathVariable("userId") long userId
@@ -69,18 +55,6 @@ public class CartController {
 
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .build();
-    }
-
-    @DeleteMapping("/users/{userId}/carts/menus/{cartMenuId}")
-    public ResponseEntity<SuccessResponseDto> deleteMenu(
-        @PathVariable("userId") long userId,
-        @PathVariable("cartMenuId") long cartMenuId
-    ) {
-        cartFacade.deleteMenuInCart(userId, cartMenuId);
-
-        return ResponseEntity
-            .status(HttpStatus.NO_CONTENT)
             .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -1,16 +1,16 @@
 package ksh.deliveryhub.cart.api;
 
+import jakarta.validation.Valid;
+import ksh.deliveryhub.cart.dto.request.CartMenuCreateRequestDto;
 import ksh.deliveryhub.cart.dto.response.CartMenuResponseDto;
 import ksh.deliveryhub.cart.dto.response.CartResponseDto;
 import ksh.deliveryhub.cart.facade.CartFacade;
+import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -21,7 +21,7 @@ public class CartController {
     private final CartFacade cartFacade;
 
     @GetMapping("/carts/{cartId}/menus")
-    public ResponseEntity getUserCart(
+    public ResponseEntity<SuccessResponseDto> getUserCart(
         @PathVariable("cartId") long cartId,
         @RequestParam("userId") long userId
     ) {
@@ -35,5 +35,18 @@ public class CartController {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(response);
+    }
+
+    @PostMapping("/carts/{cartId}/menus")
+    public ResponseEntity<SuccessResponseDto> addMenu(
+        @PathVariable("cartId") long cartId,
+        @RequestParam("userId") long userId,
+        @Valid @RequestBody CartMenuCreateRequestDto request
+    ) {
+        cartFacade.addMenuToCart(userId, request.toModel());
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -64,4 +64,17 @@ public class CartController {
             .status(HttpStatus.CREATED)
             .build();
     }
+
+    @DeleteMapping("/carts/{cartId}/menus/{cartMenuId}")
+    public ResponseEntity<SuccessResponseDto> deleteMenu(
+        @PathVariable("cartId") long cartId,
+        @PathVariable("cartMenuId") long cartMenuId,
+        @RequestParam("userId") long userId
+    ) {
+        cartFacade.deleteMenuInCart(userId, cartMenuId);
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
+    }
 }

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -38,7 +38,7 @@ public class CartController {
 
     @PostMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> addMenu(
-        @RequestParam("userId") long userId,
+        @PathVariable("userId") long userId,
         @Valid @RequestBody CartMenuCreateRequestDto request
     ) {
         cartFacade.addMenuToCart(userId, request.toModel());
@@ -50,8 +50,8 @@ public class CartController {
 
     @PostMapping("/users/{userId}/carts/menus/{cartMenuId}")
     public ResponseEntity<SuccessResponseDto> changeMenuQuantity(
+        @PathVariable("userId") long userId,
         @PathVariable("cartMenuId") long cartMenuId,
-        @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuUpdateRequestDto request
     ) {
         cartFacade.changeQuantity(userId, request.toModel(cartMenuId));
@@ -63,8 +63,7 @@ public class CartController {
 
     @PostMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> clearCart(
-        @RequestParam("userId") long userId,
-        @Valid @RequestBody CartMenuUpdateRequestDto request
+        @PathVariable("userId") long userId
     ) {
         cartFacade.clearCart(userId);
 
@@ -75,8 +74,8 @@ public class CartController {
 
     @DeleteMapping("/users/{userId}/carts/menus/{cartMenuId}")
     public ResponseEntity<SuccessResponseDto> deleteMenu(
-        @PathVariable("cartMenuId") long cartMenuId,
-        @RequestParam("userId") long userId
+        @PathVariable("userId") long userId,
+        @PathVariable("cartMenuId") long cartMenuId
     ) {
         cartFacade.deleteMenuInCart(userId, cartMenuId);
 

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -21,7 +21,7 @@ public class CartController {
     private final CartFacade cartFacade;
 
     @GetMapping("/users/{userId}/carts/menus")
-    public ResponseEntity<SuccessResponseDto> getUserCart(
+    public ResponseEntity<SuccessResponseDto> getUserCartDetails(
         @PathVariable("userId") long userId
     ) {
         List<CartMenuResponseDto> cartMenuResponseDtos = cartFacade.getUserCartMenuDetails(userId).stream()

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -20,9 +20,8 @@ public class CartController {
 
     private final CartFacade cartFacade;
 
-    @GetMapping("/carts/{cartId}/menus")
+    @GetMapping("/carts/menus")
     public ResponseEntity<SuccessResponseDto> getUserCart(
-        @PathVariable("cartId") long cartId,
         @RequestParam("userId") long userId
     ) {
         List<CartMenuResponseDto> cartMenuResponseDtos = cartFacade.getUserCartMenuDetails(userId).stream()
@@ -37,9 +36,8 @@ public class CartController {
             .body(response);
     }
 
-    @PostMapping("/carts/{cartId}/menus")
+    @PostMapping("/carts/menus")
     public ResponseEntity<SuccessResponseDto> addMenu(
-        @PathVariable("cartId") long cartId,
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuCreateRequestDto request
     ) {
@@ -50,9 +48,8 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/carts/{cartId}/menus/{cartMenuId}")
+    @PostMapping("/carts/menus/{cartMenuId}")
     public ResponseEntity<SuccessResponseDto> changeMenuQuantity(
-        @PathVariable("cartId") long cartId,
         @PathVariable("cartMenuId") long cartMenuId,
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuUpdateRequestDto request
@@ -64,9 +61,8 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/carts/{cartId}}")
+    @PostMapping("/carts}")
     public ResponseEntity<SuccessResponseDto> clearCart(
-        @PathVariable("cartId") long cartId,
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuUpdateRequestDto request
     ) {
@@ -77,9 +73,8 @@ public class CartController {
             .build();
     }
 
-    @DeleteMapping("/carts/{cartId}/menus/{cartMenuId}")
+    @DeleteMapping("/carts/menus/{cartMenuId}")
     public ResponseEntity<SuccessResponseDto> deleteMenu(
-        @PathVariable("cartId") long cartId,
         @PathVariable("cartMenuId") long cartMenuId,
         @RequestParam("userId") long userId
     ) {

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -58,7 +58,7 @@ public class CartController {
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuUpdateRequestDto request
     ) {
-        cartFacade.addMenuToCart(userId, request.toModel(cartMenuId));
+        cartFacade.changeQuantity(userId, request.toModel(cartMenuId));
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -21,10 +21,10 @@ public class CartController {
     private final CartFacade cartFacade;
 
     @GetMapping("/users/{userId}/carts/menus")
-    public ResponseEntity<SuccessResponseDto> getUserCartDetails(
+    public ResponseEntity<SuccessResponseDto> findUserCartDetails(
         @PathVariable("userId") long userId
     ) {
-        List<CartMenuResponseDto> cartMenuResponseDtos = cartFacade.getUserCartMenuDetails(userId).stream()
+        List<CartMenuResponseDto> cartMenuResponseDtos = cartFacade.findUserCartMenuDetails(userId).stream()
             .map(CartMenuResponseDto::from)
             .toList();
 

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -6,7 +6,6 @@ import ksh.deliveryhub.cart.dto.request.CartMenuUpdateRequestDto;
 import ksh.deliveryhub.cart.dto.response.CartMenuResponseDto;
 import ksh.deliveryhub.cart.dto.response.CartResponseDto;
 import ksh.deliveryhub.cart.facade.CartFacade;
-import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -59,6 +58,19 @@ public class CartController {
         @Valid @RequestBody CartMenuUpdateRequestDto request
     ) {
         cartFacade.changeQuantity(userId, request.toModel(cartMenuId));
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .build();
+    }
+
+    @PostMapping("/carts/{cartId}}")
+    public ResponseEntity<SuccessResponseDto> clearCart(
+        @PathVariable("cartId") long cartId,
+        @RequestParam("userId") long userId,
+        @Valid @RequestBody CartMenuUpdateRequestDto request
+    ) {
+        cartFacade.clearCart(userId);
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -47,7 +47,7 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/users/{userId}/carts/menus")
+    @DeleteMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> clearCart(
         @PathVariable("userId") long userId
     ) {

--- a/src/main/java/ksh/deliveryhub/cart/api/CartController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartController.java
@@ -20,9 +20,9 @@ public class CartController {
 
     private final CartFacade cartFacade;
 
-    @GetMapping("/carts")
+    @GetMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> getUserCart(
-        @RequestParam("userId") long userId
+        @PathVariable("userId") long userId
     ) {
         List<CartMenuResponseDto> cartMenuResponseDtos = cartFacade.getUserCartMenuDetails(userId).stream()
             .map(CartMenuResponseDto::from)
@@ -36,7 +36,7 @@ public class CartController {
             .body(response);
     }
 
-    @PostMapping("/carts/menus")
+    @PostMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> addMenu(
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuCreateRequestDto request
@@ -48,7 +48,7 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/carts/menus/{cartMenuId}")
+    @PostMapping("/users/{userId}/carts/menus/{cartMenuId}")
     public ResponseEntity<SuccessResponseDto> changeMenuQuantity(
         @PathVariable("cartMenuId") long cartMenuId,
         @RequestParam("userId") long userId,
@@ -61,7 +61,7 @@ public class CartController {
             .build();
     }
 
-    @PostMapping("/carts")
+    @PostMapping("/users/{userId}/carts/menus")
     public ResponseEntity<SuccessResponseDto> clearCart(
         @RequestParam("userId") long userId,
         @Valid @RequestBody CartMenuUpdateRequestDto request
@@ -73,7 +73,7 @@ public class CartController {
             .build();
     }
 
-    @DeleteMapping("/carts/menus/{cartMenuId}")
+    @DeleteMapping("/users/{userId}/carts/menus/{cartMenuId}")
     public ResponseEntity<SuccessResponseDto> deleteMenu(
         @PathVariable("cartMenuId") long cartMenuId,
         @RequestParam("userId") long userId

--- a/src/main/java/ksh/deliveryhub/cart/api/CartMenuController.java
+++ b/src/main/java/ksh/deliveryhub/cart/api/CartMenuController.java
@@ -1,0 +1,42 @@
+package ksh.deliveryhub.cart.api;
+
+import jakarta.validation.Valid;
+import ksh.deliveryhub.cart.dto.request.CartMenuUpdateRequestDto;
+import ksh.deliveryhub.cart.facade.CartFacade;
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CartMenuController {
+
+    private final CartFacade cartFacade;
+
+    @PostMapping("/users/{userId}/carts/menus/{cartMenuId}")
+    public ResponseEntity<SuccessResponseDto> changeMenuQuantity(
+        @PathVariable("userId") long userId,
+        @PathVariable("cartMenuId") long cartMenuId,
+        @Valid @RequestBody CartMenuUpdateRequestDto request
+    ) {
+        cartFacade.changeQuantity(userId, request.toModel(cartMenuId));
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .build();
+    }
+
+    @DeleteMapping("/users/{userId}/carts/menus/{cartMenuId}")
+    public ResponseEntity<SuccessResponseDto> deleteMenu(
+        @PathVariable("userId") long userId,
+        @PathVariable("cartMenuId") long cartMenuId
+    ) {
+        cartFacade.deleteMenuInCart(userId, cartMenuId);
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/dto/request/CartMenuCreateRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/cart/dto/request/CartMenuCreateRequestDto.java
@@ -1,0 +1,30 @@
+package ksh.deliveryhub.cart.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import ksh.deliveryhub.cart.model.CartMenu;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartMenuCreateRequestDto {
+
+    @NotNull(message = "메뉴 id는 필수입니다.")
+    private Long menuId;
+
+    @NotNull(message = "메뉴 옵션 id는 필수입니다.")
+    private Long optionId;
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Positive(message = "수량은 양수입니다.")
+    private Integer quantity;
+
+    public CartMenu toModel() {
+        return CartMenu.builder()
+            .quantity(getQuantity())
+            .menuId(getMenuId())
+            .optionId(getOptionId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/dto/request/CartMenuUpdateRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/cart/dto/request/CartMenuUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package ksh.deliveryhub.cart.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import ksh.deliveryhub.cart.model.CartMenu;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartMenuUpdateRequestDto {
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Positive(message = "수량은 양수입니다.")
+    private Integer quantity;
+
+    public CartMenu toModel(long id) {
+        return CartMenu.builder()
+            .id(id)
+            .quantity(getQuantity())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/dto/response/CartMenuResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/cart/dto/response/CartMenuResponseDto.java
@@ -1,0 +1,39 @@
+package ksh.deliveryhub.cart.dto.response;
+
+import ksh.deliveryhub.cart.model.CartMenu;
+import ksh.deliveryhub.cart.model.CartMenuDetail;
+import ksh.deliveryhub.menu.model.Menu;
+import ksh.deliveryhub.menu.model.MenuOption;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartMenuResponseDto {
+
+    private long id;
+    private int quantity;
+    private String menuName;
+    private String menuDescription;
+    private int menuPrice;
+    private String menuImage;
+    private String optionName;
+    private int optionPrice;
+
+    public static CartMenuResponseDto from(CartMenuDetail cartMenuDetail) {
+        CartMenu cartMenu = cartMenuDetail.getCartMenu();
+        Menu menu = cartMenuDetail.getMenu();
+        MenuOption option = cartMenuDetail.getMenuOption();
+
+        return CartMenuResponseDto.builder()
+            .id(cartMenu.getId())
+            .quantity(cartMenu.getQuantity())
+            .menuName(menu.getName())
+            .menuDescription(menu.getDescription())
+            .menuPrice(menu.getPrice())
+            .menuImage(menu.getImage())
+            .optionName(option.getName())
+            .optionPrice(option.getPrice())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/dto/response/CartMenuResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/cart/dto/response/CartMenuResponseDto.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public class CartMenuResponseDto {
 
     private long id;
+    private int totalPrice;
     private int quantity;
     private String menuName;
     private String menuDescription;
@@ -25,8 +26,13 @@ public class CartMenuResponseDto {
         Menu menu = cartMenuDetail.getMenu();
         MenuOption option = cartMenuDetail.getMenuOption();
 
+        int quantity = cartMenu.getQuantity();
+        int cartMenuPrice = menu.getPrice() + (option != null ? option.getPrice() : 0);
+        int totalPrice = quantity * cartMenuPrice;
+
         return CartMenuResponseDto.builder()
             .id(cartMenu.getId())
+            .totalPrice(totalPrice)
             .quantity(cartMenu.getQuantity())
             .menuName(menu.getName())
             .menuDescription(menu.getDescription())

--- a/src/main/java/ksh/deliveryhub/cart/dto/response/CartMenuResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/cart/dto/response/CartMenuResponseDto.java
@@ -18,7 +18,7 @@ public class CartMenuResponseDto {
     private int menuPrice;
     private String menuImage;
     private String optionName;
-    private int optionPrice;
+    private Integer optionPrice;
 
     public static CartMenuResponseDto from(CartMenuDetail cartMenuDetail) {
         CartMenu cartMenu = cartMenuDetail.getCartMenu();
@@ -32,8 +32,8 @@ public class CartMenuResponseDto {
             .menuDescription(menu.getDescription())
             .menuPrice(menu.getPrice())
             .menuImage(menu.getImage())
-            .optionName(option.getName())
-            .optionPrice(option.getPrice())
+            .optionName(option != null ? option.getName() : null)
+            .optionPrice(option != null ? option.getPrice() : null)
             .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/dto/response/CartResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/cart/dto/response/CartResponseDto.java
@@ -1,0 +1,19 @@
+package ksh.deliveryhub.cart.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CartResponseDto {
+
+    private List<CartMenuResponseDto> menus;
+
+    public static CartResponseDto of(List<CartMenuResponseDto> cartMenuResponseDtos) {
+        return CartResponseDto.builder()
+            .menus(cartMenuResponseDtos)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartEntity.java
@@ -1,0 +1,41 @@
+package ksh.deliveryhub.cart.entity;
+
+import jakarta.persistence.*;
+import ksh.deliveryhub.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "cart")
+public class CartEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated
+    private CartStatus status;
+
+    private LocalDateTime expireAt;
+
+    private Long userId;
+
+    @Builder
+    private CartEntity(
+        Long id,
+        CartStatus status,
+        LocalDateTime expireAt,
+        Long userId
+    ) {
+        this.id = id;
+        this.status = status;
+        this.expireAt = expireAt;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
@@ -25,8 +25,8 @@ public class CartMenuEntity extends BaseEntity {
 
     private Long optionId;
 
-    public void increaseQuantity(Integer quantity) {
-        this.quantity += quantity;
+    public void updateQuantity(Integer quantity) {
+        this.quantity = quantity;
     }
 
     @Builder

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
@@ -25,6 +25,10 @@ public class CartMenuEntity extends BaseEntity {
 
     private Long optionId;
 
+    public void increaseQuantity(Integer quantity) {
+        this.quantity += quantity;
+    }
+
     @Builder
     private CartMenuEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
@@ -23,7 +23,7 @@ public class CartMenuEntity extends BaseEntity {
 
     private Long menuId;
 
-    private Long orderId;
+    private Long optionId;
 
     @Builder
     private CartMenuEntity(
@@ -31,12 +31,12 @@ public class CartMenuEntity extends BaseEntity {
         Integer quantity,
         Long cartId,
         Long menuId,
-        Long orderId
+        Long optionId
     ) {
         this.id = id;
         this.quantity = quantity;
         this.cartId = cartId;
         this.menuId = menuId;
-        this.orderId = orderId;
+        this.optionId = optionId;
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
@@ -1,0 +1,42 @@
+package ksh.deliveryhub.cart.entity;
+
+import jakarta.persistence.*;
+import ksh.deliveryhub.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "cart_menu")
+public class CartMenuEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer quantity;
+
+    private Long cartId;
+
+    private Long menuId;
+
+    private Long orderId;
+
+    @Builder
+    private CartMenuEntity(
+        Long id,
+        Integer quantity,
+        Long cartId,
+        Long menuId,
+        Long orderId
+    ) {
+        this.id = id;
+        this.quantity = quantity;
+        this.cartId = cartId;
+        this.menuId = menuId;
+        this.orderId = orderId;
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartMenuEntity.java
@@ -29,6 +29,10 @@ public class CartMenuEntity extends BaseEntity {
         this.quantity = quantity;
     }
 
+    public void incrementQuantity(Integer quantity) {
+        this.quantity += quantity;
+    }
+
     @Builder
     private CartMenuEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartStatus.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartStatus.java
@@ -1,0 +1,6 @@
+package ksh.deliveryhub.cart.entity;
+
+public enum CartStatus {
+    ACTIVE,
+    ORDERED
+}

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -4,8 +4,7 @@ import ksh.deliveryhub.cart.model.Cart;
 import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.cart.service.CartMenuService;
 import ksh.deliveryhub.cart.service.CartService;
-import ksh.deliveryhub.common.exception.CustomException;
-import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.menu.service.MenuOptionService;
 import ksh.deliveryhub.menu.service.MenuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,10 +16,12 @@ public class CartFacade {
     private final CartService cartService;
     private final CartMenuService cartMenuService;
     private final MenuService menuService;
+    private final MenuOptionService menuOptionService;
 
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
-        menuService.checkAvailability(cartMenu.getMenuId());
+        menuService.getAvailableMenu(cartMenu.getMenuId());
+        menuOptionService.getOptionIsInMenu(cartMenu.getOptionId(), cartMenu.getMenuId());
 
         return cartMenuService.addCartMenu(cart.getId(), cartMenu);
     }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -28,10 +28,10 @@ public class CartFacade {
 
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
-        menuService.getAvailableMenu(cartMenu.getMenuId());
+        Menu selectedMenu = menuService.getAvailableMenu(cartMenu.getMenuId());
         menuOptionService.getOptionInMenu(cartMenu.getOptionId(), cartMenu.getMenuId());
 
-        return cartMenuService.addCartMenu(cart.getId(), cartMenu);
+        return cartMenuService.addCartMenu(cart.getId(), cartMenu, selectedMenu.getStoreId());
     }
 
     public void changeQuantity(long userId, CartMenu cartMenu) {

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -11,6 +11,7 @@ import ksh.deliveryhub.menu.service.MenuOptionService;
 import ksh.deliveryhub.menu.service.MenuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ public class CartFacade {
     private final MenuService menuService;
     private final MenuOptionService menuOptionService;
 
+    @Transactional
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
         Menu selectedMenu = menuService.getAvailableMenu(cartMenu.getMenuId());
@@ -36,21 +38,25 @@ public class CartFacade {
         return cartMenuService.addCartMenu(cart.getId(), cartMenu, selectedMenu.getStoreId());
     }
 
+    @Transactional
     public void changeQuantity(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
         cartMenuService.changeQuantity(cart.getId(), cartMenu);
     }
 
+    @Transactional
     public void deleteMenuInCart(long userId, long cartMenuId) {
         Cart cart = cartService.getUserCart(userId);
         cartMenuService.deleteCartMenu(cartMenuId, cart.getId());
     }
 
+    @Transactional
     public void clearCart(long userId) {
         Cart cart = cartService.getUserCart(userId);
         cartMenuService.clearCartMenuOfUser(cart.getId());
     }
 
+    @Transactional(readOnly = true)
     public List<CartMenuDetail> findUserCartMenuDetails(long userId) {
         Cart cart = cartService.getUserCart(userId);
         List<CartMenu> cartMenus = cartMenuService.findCartMenusInCart(cart.getId());

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -39,9 +39,9 @@ public class CartFacade {
         cartMenuService.changeQuantity(cart.getId(), cartMenu);
     }
 
-    public void deleteMenuInCart(long userId, CartMenu cartMenu) {
+    public void deleteMenuInCart(long userId, long cartMenuId) {
         Cart cart = cartService.getUserCart(userId);
-        cartMenuService.deleteCartMenu(cartMenu.getId(), cart.getId());
+        cartMenuService.deleteCartMenu(cartMenuId, cart.getId());
     }
 
     public void clearCart(long userId) {

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -1,0 +1,21 @@
+package ksh.deliveryhub.cart.facade;
+
+import ksh.deliveryhub.cart.model.Cart;
+import ksh.deliveryhub.cart.model.CartMenu;
+import ksh.deliveryhub.cart.service.CartMenuService;
+import ksh.deliveryhub.cart.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CartFacade {
+
+    private final CartService cartService;
+    private final CartMenuService cartMenuService;
+
+    public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
+        Cart cart = cartService.getUserCart(userId);
+        return cartMenuService.addCartMenu(cart.getId(), cartMenu);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -29,7 +29,9 @@ public class CartFacade {
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
         Menu selectedMenu = menuService.getAvailableMenu(cartMenu.getMenuId());
-        menuOptionService.getOptionInMenu(cartMenu.getOptionId(), cartMenu.getMenuId());
+        if(cartMenu.getOptionId() != null){
+            menuOptionService.getOptionInMenu(cartMenu.getOptionId(), cartMenu.getMenuId());
+        }
 
         return cartMenuService.addCartMenu(cart.getId(), cartMenu, selectedMenu.getStoreId());
     }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -49,7 +49,7 @@ public class CartFacade {
         cartMenuService.clearCartMenuOfUser(cart.getId());
     }
 
-    public List<CartMenuDetail> getUserCartMenuDetails(long userId) {
+    public List<CartMenuDetail> findUserCartMenuDetails(long userId) {
         Cart cart = cartService.getUserCart(userId);
         List<CartMenu> cartMenus = cartMenuService.findCartMenusInCart(cart.getId());
         List<Menu> menusInCart = menuService.findMenusInCart(cartMenus);

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -4,6 +4,7 @@ import ksh.deliveryhub.cart.model.Cart;
 import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.cart.service.CartMenuService;
 import ksh.deliveryhub.cart.service.CartService;
+import ksh.deliveryhub.menu.service.MenuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,9 +14,11 @@ public class CartFacade {
 
     private final CartService cartService;
     private final CartMenuService cartMenuService;
+    private final MenuService menuService;
 
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
+        menuService.checkAvailability(cartMenu.getMenuId());
         return cartMenuService.addCartMenu(cart.getId(), cartMenu);
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -35,4 +35,9 @@ public class CartFacade {
         Cart cart = cartService.getUserCart(userId);
         cartMenuService.deleteCartMenu(cartMenu.getId(), cart.getId());
     }
+
+    public void clearCart(long userId) {
+        Cart cart = cartService.getUserCart(userId);
+        cartMenuService.clearCartMenuOfUser(cart.getId());
+    }
 }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -29,7 +29,7 @@ public class CartFacade {
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
         menuService.getAvailableMenu(cartMenu.getMenuId());
-        menuOptionService.getOptionIsInMenu(cartMenu.getOptionId(), cartMenu.getMenuId());
+        menuOptionService.getOptionInMenu(cartMenu.getOptionId(), cartMenu.getMenuId());
 
         return cartMenuService.addCartMenu(cart.getId(), cartMenu);
     }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -4,6 +4,8 @@ import ksh.deliveryhub.cart.model.Cart;
 import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.cart.service.CartMenuService;
 import ksh.deliveryhub.cart.service.CartService;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.menu.service.MenuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,6 +21,12 @@ public class CartFacade {
     public CartMenu addMenuToCart(long userId, CartMenu cartMenu) {
         Cart cart = cartService.getUserCart(userId);
         menuService.checkAvailability(cartMenu.getMenuId());
+
         return cartMenuService.addCartMenu(cart.getId(), cartMenu);
+    }
+
+    public void changeQuantity(long userId, CartMenu cartMenu) {
+        Cart cart = cartService.getUserCart(userId);
+        cartMenuService.changeQuantity(cart.getId(), cartMenu);
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -30,4 +30,9 @@ public class CartFacade {
         Cart cart = cartService.getUserCart(userId);
         cartMenuService.changeQuantity(cart.getId(), cartMenu);
     }
+
+    public void deleteMenuInCart(long userId, CartMenu cartMenu) {
+        Cart cart = cartService.getUserCart(userId);
+        cartMenuService.deleteCartMenu(cartMenu.getId(), cart.getId());
+    }
 }

--- a/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
+++ b/src/main/java/ksh/deliveryhub/cart/facade/CartFacade.java
@@ -65,8 +65,8 @@ public class CartFacade {
             .map(cm -> CartMenuDetail.of(
                 cm,
                 menuMap.get(cm.getMenuId()),
-                optionMap.get(cm.getOptionId()))
-            )
+                optionMap.get(cm.getOptionId())
+            ))
             .toList();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/model/Cart.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/Cart.java
@@ -1,0 +1,36 @@
+package ksh.deliveryhub.cart.model;
+
+import ksh.deliveryhub.cart.entity.CartEntity;
+import ksh.deliveryhub.cart.entity.CartStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class Cart {
+
+    private Long id;
+    private CartStatus status;
+    private LocalDateTime expireAt;
+    private Long userId;
+
+    public static Cart from(CartEntity cartEntity) {
+        return Cart.builder()
+            .id(cartEntity.getId())
+            .status(cartEntity.getStatus())
+            .expireAt(cartEntity.getExpireAt())
+            .userId(cartEntity.getUserId())
+            .build();
+    }
+
+    public CartEntity toEntity() {
+        return CartEntity.builder()
+            .id(getId())
+            .status(getStatus())
+            .expireAt(getExpireAt())
+            .userId(getUserId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/model/CartMenu.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/CartMenu.java
@@ -12,25 +12,25 @@ public class CartMenu {
     private Integer quantity;
     private Long cartId;
     private Long menuId;
-    private Long orderId;
+    private Long optionId;
 
-    private static CartMenu from(CartMenuEntity cartMenuEntity) {
+    public static CartMenu from(CartMenuEntity cartMenuEntity) {
         return CartMenu.builder()
             .id(cartMenuEntity.getId())
             .quantity(cartMenuEntity.getQuantity())
             .cartId(cartMenuEntity.getCartId())
             .menuId(cartMenuEntity.getMenuId())
-            .orderId(cartMenuEntity.getOrderId())
+            .optionId(cartMenuEntity.getOptionId())
             .build();
     }
 
-    private CartMenu toEntity() {
-        return CartMenu.builder()
+    public CartMenuEntity toEntity() {
+        return CartMenuEntity.builder()
             .id(getId())
             .quantity(getQuantity())
             .cartId(getCartId())
             .menuId(getMenuId())
-            .orderId(getOrderId())
+            .optionId(getOptionId())
             .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/model/CartMenu.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/CartMenu.java
@@ -1,0 +1,36 @@
+package ksh.deliveryhub.cart.model;
+
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartMenu {
+
+    private Long id;
+    private Integer quantity;
+    private Long cartId;
+    private Long menuId;
+    private Long orderId;
+
+    private static CartMenu from(CartMenuEntity cartMenuEntity) {
+        return CartMenu.builder()
+            .id(cartMenuEntity.getId())
+            .quantity(cartMenuEntity.getQuantity())
+            .cartId(cartMenuEntity.getCartId())
+            .menuId(cartMenuEntity.getMenuId())
+            .orderId(cartMenuEntity.getOrderId())
+            .build();
+    }
+
+    private CartMenu toEntity() {
+        return CartMenu.builder()
+            .id(getId())
+            .quantity(getQuantity())
+            .cartId(getCartId())
+            .menuId(getMenuId())
+            .orderId(getOrderId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
@@ -1,0 +1,33 @@
+package ksh.deliveryhub.cart.model;
+
+import ksh.deliveryhub.menu.model.Menu;
+import ksh.deliveryhub.menu.model.MenuOption;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartMenuDetail {
+
+    private long id;
+    private int quantity;
+    private String menuName;
+    private String menuDescription;
+    private int menuPrice;
+    private String menuImage;
+    private String optionName;
+    private int optionPrice;
+
+    public static CartMenuDetail of(CartMenu cartMenu, Menu menu, MenuOption option) {
+        return CartMenuDetail.builder()
+            .id(cartMenu.getId())
+            .quantity(cartMenu.getQuantity())
+            .menuName(menu.getName())
+            .menuDescription(menu.getDescription())
+            .menuPrice(menu.getPrice())
+            .menuImage(menu.getImage())
+            .optionName(option.getName())
+            .optionPrice(option.getPrice())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
@@ -9,25 +9,15 @@ import lombok.Getter;
 @Builder
 public class CartMenuDetail {
 
-    private long id;
-    private int quantity;
-    private String menuName;
-    private String menuDescription;
-    private int menuPrice;
-    private String menuImage;
-    private String optionName;
-    private int optionPrice;
+    private CartMenu cartMenu;
+    private Menu menu;
+    private MenuOption menuOption;
 
-    public static CartMenuDetail of(CartMenu cartMenu, Menu menu, MenuOption option) {
+    public static CartMenuDetail of(CartMenu cartMenu, Menu menu, MenuOption menuOption) {
         return CartMenuDetail.builder()
-            .id(cartMenu.getId())
-            .quantity(cartMenu.getQuantity())
-            .menuName(menu.getName())
-            .menuDescription(menu.getDescription())
-            .menuPrice(menu.getPrice())
-            .menuImage(menu.getImage())
-            .optionName(option.getName())
-            .optionPrice(option.getPrice())
+            .cartMenu(cartMenu)
+            .menu(menu)
+            .menuOption(menuOption)
             .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface CartMenuQueryRepository {
 
-    Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, long optionId);
+    Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, Long optionId);
 
     Long findStoreIdOfExistingMenu(long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepository.java
@@ -1,0 +1,10 @@
+package ksh.deliveryhub.cart.repository;
+
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+
+import java.util.Optional;
+
+public interface CartMenuQueryRepository {
+
+    Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, long optionId);
+}

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface CartMenuQueryRepository {
 
     Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, long optionId);
+
+    Long findStoreIdOfExistingMenu(long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package ksh.deliveryhub.cart.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import ksh.deliveryhub.cart.entity.QCartMenuEntity;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CartMenuQueryRepositoryImpl implements CartMenuQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, long optionId) {
+        CartMenuEntity cartMenuEntity = queryFactory
+            .select(QCartMenuEntity.cartMenuEntity)
+            .from(QCartMenuEntity.cartMenuEntity)
+            .where(
+                QCartMenuEntity.cartMenuEntity.cartId.eq(cartId),
+                QCartMenuEntity.cartMenuEntity.menuId.eq(menuId),
+                QCartMenuEntity.cartMenuEntity.optionId.eq(optionId)
+            )
+            .fetchOne();
+
+        return Optional.ofNullable(cartMenuEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
@@ -2,10 +2,12 @@ package ksh.deliveryhub.cart.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import ksh.deliveryhub.cart.entity.CartMenuEntity;
-import ksh.deliveryhub.cart.entity.QCartMenuEntity;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
+
+import static ksh.deliveryhub.cart.entity.QCartMenuEntity.cartMenuEntity;
+import static ksh.deliveryhub.menu.entity.QMenuEntity.menuEntity;
 
 @RequiredArgsConstructor
 public class CartMenuQueryRepositoryImpl implements CartMenuQueryRepository {
@@ -15,16 +17,28 @@ public class CartMenuQueryRepositoryImpl implements CartMenuQueryRepository {
 
     @Override
     public Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, long optionId) {
-        CartMenuEntity cartMenuEntity = queryFactory
-            .select(QCartMenuEntity.cartMenuEntity)
-            .from(QCartMenuEntity.cartMenuEntity)
+        CartMenuEntity entity = queryFactory
+            .select(cartMenuEntity)
+            .from(cartMenuEntity)
             .where(
-                QCartMenuEntity.cartMenuEntity.cartId.eq(cartId),
-                QCartMenuEntity.cartMenuEntity.menuId.eq(menuId),
-                QCartMenuEntity.cartMenuEntity.optionId.eq(optionId)
+                cartMenuEntity.cartId.eq(cartId),
+                cartMenuEntity.menuId.eq(menuId),
+                cartMenuEntity.optionId.eq(optionId)
             )
             .fetchOne();
 
-        return Optional.ofNullable(cartMenuEntity);
+        return Optional.ofNullable(entity);
+    }
+
+    @Override
+    public Long findStoreIdOfExistingMenu(long cartId) {
+        return queryFactory
+            .select(menuEntity.storeId)
+            .from(cartMenuEntity)
+            .join(menuEntity)
+            .on(cartMenuEntity.menuId.eq(menuEntity.id))
+            .where(cartMenuEntity.cartId.eq(cartId))
+            .limit(1)
+            .fetchOne();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.cart.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import ksh.deliveryhub.cart.entity.CartMenuEntity;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +17,16 @@ public class CartMenuQueryRepositoryImpl implements CartMenuQueryRepository {
 
 
     @Override
-    public Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, long optionId) {
+    public Optional<CartMenuEntity> findMenuInCart(long cartId, long menuId, Long optionId) {
+        BooleanExpression optionIdEqual = optionId == null ? cartMenuEntity.optionId.isNull() : cartMenuEntity.optionId.eq(optionId);
+
         CartMenuEntity entity = queryFactory
             .select(cartMenuEntity)
             .from(cartMenuEntity)
             .where(
                 cartMenuEntity.cartId.eq(cartId),
                 cartMenuEntity.menuId.eq(menuId),
-                cartMenuEntity.optionId.eq(optionId)
+                optionIdEqual
             )
             .fetchOne();
 

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
@@ -3,5 +3,9 @@ package ksh.deliveryhub.cart.repository;
 import ksh.deliveryhub.cart.entity.CartMenuEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CartMenuRepository extends JpaRepository<CartMenuEntity, Long>, CartMenuQueryRepository {
+
+    Optional<CartMenuEntity> findByIdAndCartId(long id, long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.cart.repository;
+
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartMenuRepository extends JpaRepository<CartMenuEntity, Long>, CartMenuQueryRepository {
+}

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface CartMenuRepository extends JpaRepository<CartMenuEntity, Long>, CartMenuQueryRepository {
 
     Optional<CartMenuEntity> findByIdAndCartId(long id, long cartId);
+
+    void deleteByCartId(long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuRepository.java
@@ -3,9 +3,12 @@ package ksh.deliveryhub.cart.repository;
 import ksh.deliveryhub.cart.entity.CartMenuEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CartMenuRepository extends JpaRepository<CartMenuEntity, Long>, CartMenuQueryRepository {
+
+    List<CartMenuEntity> findByCartId(long cartId);
 
     Optional<CartMenuEntity> findByIdAndCartId(long id, long cartId);
 

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartRepository.java
@@ -1,11 +1,12 @@
 package ksh.deliveryhub.cart.repository;
 
 import ksh.deliveryhub.cart.entity.CartEntity;
+import ksh.deliveryhub.cart.entity.CartStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<CartEntity, Long> {
 
-    Optional<CartEntity> findByUserId(long userId);
+    Optional<CartEntity> findByUserIdAndStatus(long userId, CartStatus status);
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartRepository.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartRepository.java
@@ -1,0 +1,11 @@
+package ksh.deliveryhub.cart.repository;
+
+import ksh.deliveryhub.cart.entity.CartEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<CartEntity, Long> {
+
+    Optional<CartEntity> findByUserId(long userId);
+}

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -6,5 +6,7 @@ public interface CartMenuService {
 
     CartMenu addCartMenu(long cartId, CartMenu cartMenu);
 
-    void changeQuantity(long userCartId, CartMenu cartMenu);
+    void changeQuantity(long cartId, CartMenu cartMenu);
+
+    void deleteCartMenu(long id, long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -1,0 +1,8 @@
+package ksh.deliveryhub.cart.service;
+
+import ksh.deliveryhub.cart.model.CartMenu;
+
+public interface CartMenuService {
+
+    CartMenu addCartMenu(long cartId, CartMenu cartMenu);
+}

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -9,4 +9,6 @@ public interface CartMenuService {
     void changeQuantity(long cartId, CartMenu cartMenu);
 
     void deleteCartMenu(long id, long cartId);
+
+    void clearCartMenuOfUser(long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface CartMenuService {
 
-    CartMenu addCartMenu(long cartId, CartMenu cartMenu);
+    CartMenu addCartMenu(long cartId, CartMenu cartMenu, long storeIdOfNewMenu);
 
     void changeQuantity(long cartId, CartMenu cartMenu);
 

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -5,4 +5,6 @@ import ksh.deliveryhub.cart.model.CartMenu;
 public interface CartMenuService {
 
     CartMenu addCartMenu(long cartId, CartMenu cartMenu);
+
+    void changeQuantity(long userCartId, CartMenu cartMenu);
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -2,6 +2,8 @@ package ksh.deliveryhub.cart.service;
 
 import ksh.deliveryhub.cart.model.CartMenu;
 
+import java.util.List;
+
 public interface CartMenuService {
 
     CartMenu addCartMenu(long cartId, CartMenu cartMenu);
@@ -11,4 +13,6 @@ public interface CartMenuService {
     void deleteCartMenu(long id, long cartId);
 
     void clearCartMenuOfUser(long cartId);
+
+    List<CartMenu> findCartMenusInCart(long userId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -32,7 +32,7 @@ public class CartMenuServiceImpl implements CartMenuService {
 
         if (optional.isPresent()) {
             CartMenuEntity cartMenuEntity = optional.get();
-            cartMenuEntity.updateQuantity(cartMenu.getQuantity());
+            cartMenuEntity.incrementQuantity(cartMenu.getQuantity());
             return CartMenu.from(cartMenuEntity);
         }
 

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -18,7 +18,12 @@ public class CartMenuServiceImpl implements CartMenuService {
     private final CartMenuRepository cartMenuRepository;
 
     @Override
-    public CartMenu addCartMenu(long cartId, CartMenu cartMenu) {
+    public CartMenu addCartMenu(long cartId, CartMenu cartMenu, long storeIdOfNewMenu) {
+        Long storeIdOfExistingMenu = cartMenuRepository.findStoreIdOfExistingMenu(cartId);
+        if(storeIdOfExistingMenu != null && storeIdOfExistingMenu != storeIdOfNewMenu) {
+            throw new CustomException(ErrorCode.CART_MENU_STORE_CONFLICT);
+        }
+
         Optional<CartMenuEntity> optional = cartMenuRepository.findMenuInCart(
             cartId,
             cartMenu.getMenuId(),

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -8,6 +8,7 @@ import ksh.deliveryhub.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -58,5 +59,12 @@ public class CartMenuServiceImpl implements CartMenuService {
     @Override
     public void clearCartMenuOfUser(long cartId) {
         cartMenuRepository.deleteByCartId(cartId);
+    }
+
+    @Override
+    public List<CartMenu> findCartMenusInCart(long cartId) {
+        return cartMenuRepository.findByCartId(cartId).stream()
+            .map(CartMenu::from)
+            .toList();
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -35,8 +35,8 @@ public class CartMenuServiceImpl implements CartMenuService {
     }
 
     @Override
-    public void changeQuantity(long userCartId, CartMenu cartMenu) {
-        CartMenuEntity cartMenuEntity = cartMenuRepository.findByIdAndCartId(cartMenu.getId(), userCartId)
+    public void changeQuantity(long cartId, CartMenu cartMenu) {
+        CartMenuEntity cartMenuEntity = cartMenuRepository.findByIdAndCartId(cartMenu.getId(), cartId)
             .orElseThrow(() -> new CustomException(ErrorCode.CART_MENU_NOT_FOUND));
 
         if(cartMenu.getQuantity() < 1) {
@@ -45,5 +45,13 @@ public class CartMenuServiceImpl implements CartMenuService {
         }
 
         cartMenuEntity.updateQuantity(cartMenu.getQuantity());
+    }
+
+    @Override
+    public void deleteCartMenu(long id, long cartId) {
+        CartMenuEntity cartMenuEntity = cartMenuRepository.findByIdAndCartId(id, cartId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CART_MENU_NOT_FOUND));
+
+        cartMenuRepository.delete(cartMenuEntity);
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -7,6 +7,7 @@ import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +41,7 @@ public class CartMenuServiceImpl implements CartMenuService {
         return CartMenu.from(savedEntity);
     }
 
+    @Transactional
     @Override
     public void changeQuantity(long cartId, CartMenu cartMenu) {
         CartMenuEntity cartMenuEntity = cartMenuRepository.findByIdAndCartId(cartMenu.getId(), cartId)

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -3,6 +3,8 @@ package ksh.deliveryhub.cart.service;
 import ksh.deliveryhub.cart.entity.CartMenuEntity;
 import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.cart.repository.CartMenuRepository;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,11 +26,24 @@ public class CartMenuServiceImpl implements CartMenuService {
 
         if (optional.isPresent()) {
             CartMenuEntity cartMenuEntity = optional.get();
-            cartMenuEntity.increaseQuantity(cartMenu.getQuantity());
+            cartMenuEntity.updateQuantity(cartMenu.getQuantity());
             return CartMenu.from(cartMenuEntity);
         }
 
         CartMenuEntity savedEntity = cartMenuRepository.save(cartMenu.toEntity());
         return CartMenu.from(savedEntity);
+    }
+
+    @Override
+    public void changeQuantity(long userCartId, CartMenu cartMenu) {
+        CartMenuEntity cartMenuEntity = cartMenuRepository.findByIdAndCartId(cartMenu.getId(), userCartId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CART_MENU_NOT_FOUND));
+
+        if(cartMenu.getQuantity() < 1) {
+            cartMenuRepository.delete(cartMenuEntity);
+            return;
+        }
+
+        cartMenuEntity.updateQuantity(cartMenu.getQuantity());
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -1,0 +1,34 @@
+package ksh.deliveryhub.cart.service;
+
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import ksh.deliveryhub.cart.model.CartMenu;
+import ksh.deliveryhub.cart.repository.CartMenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CartMenuServiceImpl implements CartMenuService {
+
+    private final CartMenuRepository cartMenuRepository;
+
+    @Override
+    public CartMenu addCartMenu(long cartId, CartMenu cartMenu) {
+        Optional<CartMenuEntity> optional = cartMenuRepository.findMenuInCart(
+            cartId,
+            cartMenu.getMenuId(),
+            cartMenu.getOptionId()
+        );
+
+        if (optional.isPresent()) {
+            CartMenuEntity cartMenuEntity = optional.get();
+            cartMenuEntity.increaseQuantity(cartMenu.getQuantity());
+            return CartMenu.from(cartMenuEntity);
+        }
+
+        CartMenuEntity savedEntity = cartMenuRepository.save(cartMenu.toEntity());
+        return CartMenu.from(savedEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -54,4 +54,9 @@ public class CartMenuServiceImpl implements CartMenuService {
 
         cartMenuRepository.delete(cartMenuEntity);
     }
+
+    @Override
+    public void clearCartMenuOfUser(long cartId) {
+        cartMenuRepository.deleteByCartId(cartId);
+    }
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartService.java
@@ -1,0 +1,8 @@
+package ksh.deliveryhub.cart.service;
+
+import ksh.deliveryhub.cart.model.Cart;
+
+public interface CartService {
+
+    Cart getUserCart(long userId);
+}

--- a/src/main/java/ksh/deliveryhub/cart/service/CartServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartServiceImpl.java
@@ -17,7 +17,7 @@ public class CartServiceImpl implements CartService {
 
     @Override
     public Cart getUserCart(long userId) {
-        CartEntity userCartEntity = cartRepository.findByUserId(userId)
+        CartEntity userCartEntity = cartRepository.findByUserIdAndStatus(userId, CartStatus.ACTIVE)
             .orElseGet(() -> cartRepository.save(createCartEntity(userId)));
 
         return Cart.from(userCartEntity);

--- a/src/main/java/ksh/deliveryhub/cart/service/CartServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartServiceImpl.java
@@ -1,0 +1,35 @@
+package ksh.deliveryhub.cart.service;
+
+import ksh.deliveryhub.cart.entity.CartEntity;
+import ksh.deliveryhub.cart.entity.CartStatus;
+import ksh.deliveryhub.cart.model.Cart;
+import ksh.deliveryhub.cart.repository.CartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CartServiceImpl implements CartService {
+
+    private final CartRepository cartRepository;
+
+    @Override
+    public Cart getUserCart(long userId) {
+        CartEntity userCartEntity = cartRepository.findByUserId(userId)
+            .orElseGet(() -> cartRepository.save(createCartEntity(userId)));
+
+        return Cart.from(userCartEntity);
+    }
+
+    private static CartEntity createCartEntity(long userId) {
+        LocalDateTime expireAt = LocalDateTime.now().plusHours(1);
+
+        return CartEntity.builder()
+            .status(CartStatus.ACTIVE)
+            .expireAt(expireAt)
+            .userId(userId)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
     MENU_NOT_FOUND(404, "menu.not.found"),
     MENU_STORE_ID_MISMATCH(403, "menu.store.id.mismatch"),
     MENU_NOT_AVAILABLE(400, "menu.not.available"),
-    MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid");
+    MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid"),
+    CART_MENU_NOT_FOUND(404, "cart.menu.not.found"),
+    CART_MENU_NOT_FOUND_IN_CART(404, "cart.menu.not.found.in.cart");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -14,9 +14,7 @@ public enum ErrorCode {
     MENU_NOT_AVAILABLE(400, "menu.not.available"),
     MENU_OPTION_NOT_FOUND(404, "menu.option.not.found"),
     MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid"),
-    MENU_OPTION_NOT_FOUND_IN_MENU(404, "menu.option.not.found.in.menu"),
-    CART_MENU_NOT_FOUND(404, "cart.menu.not.found"),
-    CART_MENU_NOT_FOUND_IN_CART(404, "cart.menu.not.found.in.cart");
+    CART_MENU_NOT_FOUND(404, "cart.menu.not.found");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     MENU_NOT_AVAILABLE(400, "menu.not.available"),
     MENU_OPTION_NOT_FOUND(404, "menu.option.not.found"),
     MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid"),
-    CART_MENU_NOT_FOUND(404, "cart.menu.not.found");
+    CART_MENU_NOT_FOUND(404, "cart.menu.not.found"),
+    CART_MENU_STORE_CONFLICT(400, "cart.menu.store.conflict");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     STORE_INVALID_PHONE(400, "store.invalid.phone"),
     MENU_NOT_FOUND(404, "menu.not.found"),
     MENU_STORE_ID_MISMATCH(403, "menu.store.id.mismatch"),
+    MENU_NOT_AVAILABLE(400, "menu.not.available"),
     MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid");
 
     private final int status;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
     MENU_NOT_FOUND(404, "menu.not.found"),
     MENU_STORE_ID_MISMATCH(403, "menu.store.id.mismatch"),
     MENU_NOT_AVAILABLE(400, "menu.not.available"),
+    MENU_OPTION_NOT_FOUND(404, "menu.option.not.found"),
     MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid"),
+    MENU_OPTION_NOT_FOUND_IN_MENU(404, "menu.option.not.found.in.menu"),
     CART_MENU_NOT_FOUND(404, "cart.menu.not.found"),
     CART_MENU_NOT_FOUND_IN_CART(404, "cart.menu.not.found.in.cart");
 

--- a/src/main/java/ksh/deliveryhub/menu/repository/MenuOptionRepository.java
+++ b/src/main/java/ksh/deliveryhub/menu/repository/MenuOptionRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MenuOptionRepository extends JpaRepository<MenuOptionEntity, Long> {
+
     List<MenuOptionEntity> findByMenuId(long menuId);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionService.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionService.java
@@ -11,4 +11,6 @@ public interface MenuOptionService {
     List<MenuOption> updateOptions(List<MenuOption> menuOptions);
 
     List<MenuOption> deleteMenuOptionsOfMenu(long menuId);
+
+    MenuOption getOptionIsInMenu(long id, long menuId);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionService.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionService.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.menu.service;
 
+import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.menu.model.MenuOption;
 
 import java.util.List;
@@ -13,4 +14,6 @@ public interface MenuOptionService {
     List<MenuOption> deleteMenuOptionsOfMenu(long menuId);
 
     MenuOption getOptionIsInMenu(long id, long menuId);
+
+    List<MenuOption> findOptionsOfCartMenu(List<CartMenu> cartMenus);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionService.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionService.java
@@ -13,7 +13,7 @@ public interface MenuOptionService {
 
     List<MenuOption> deleteMenuOptionsOfMenu(long menuId);
 
-    MenuOption getOptionIsInMenu(long id, long menuId);
+    MenuOption getOptionInMenu(long id, long menuId);
 
     List<MenuOption> findOptionsOfCartMenu(List<CartMenu> cartMenus);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
@@ -74,7 +74,7 @@ public class MenuOptionServiceImpl implements MenuOptionService {
     }
 
     @Override
-    public MenuOption getOptionIsInMenu(long id, long menuId) {
+    public MenuOption getOptionInMenu(long id, long menuId) {
         MenuOptionEntity optionEntity = menuOptionRepository.findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND));
 

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
@@ -78,7 +78,7 @@ public class MenuOptionServiceImpl implements MenuOptionService {
             .orElseThrow(() -> new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND));
 
         if(optionEntity.getMenuId() != menuId) {
-            throw new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND_IN_MENU);
+            throw new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND);
         }
 
         return MenuOption.from(optionEntity);

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
@@ -71,4 +71,16 @@ public class MenuOptionServiceImpl implements MenuOptionService {
             .map(MenuOption::from)
             .toList();
     }
+
+    @Override
+    public MenuOption getOptionIsInMenu(long id, long menuId) {
+        MenuOptionEntity optionEntity = menuOptionRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND));
+
+        if(optionEntity.getMenuId() != menuId) {
+            throw new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND_IN_MENU);
+        }
+
+        return MenuOption.from(optionEntity);
+    }
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuOptionServiceImpl.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.menu.service;
 
+import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.menu.entity.MenuOptionEntity;
@@ -82,5 +83,16 @@ public class MenuOptionServiceImpl implements MenuOptionService {
         }
 
         return MenuOption.from(optionEntity);
+    }
+
+    @Override
+    public List<MenuOption> findOptionsOfCartMenu(List<CartMenu> cartMenus) {
+        List<Long> ids = cartMenus.stream()
+            .map(CartMenu::getOptionId)
+            .toList();
+
+        return menuOptionRepository.findAllById(ids).stream()
+            .map(MenuOption::from)
+            .toList();
     }
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuService.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuService.java
@@ -1,6 +1,9 @@
 package ksh.deliveryhub.menu.service;
 
+import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.menu.model.Menu;
+
+import java.util.List;
 
 public interface MenuService {
 
@@ -11,4 +14,6 @@ public interface MenuService {
     Menu deleteMenu(long id, long storeId);
 
     Menu getAvailableMenu(long menuId);
+
+    List<Menu> findMenusInCart(List<CartMenu> cartMenus);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuService.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuService.java
@@ -10,5 +10,5 @@ public interface MenuService {
 
     Menu deleteMenu(long id, long storeId);
 
-    void checkAvailability(long menuId);
+    Menu getAvailableMenu(long menuId);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuService.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuService.java
@@ -9,4 +9,6 @@ public interface MenuService {
     Menu updateMenu(Menu menu);
 
     Menu deleteMenu(long id, long storeId);
+
+    void checkAvailability(long menuId);
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuServiceImpl.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.menu.service;
 
+import ksh.deliveryhub.cart.model.CartMenu;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.menu.entity.MenuEntity;
@@ -8,6 +9,8 @@ import ksh.deliveryhub.menu.model.Menu;
 import ksh.deliveryhub.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -66,5 +69,16 @@ public class MenuServiceImpl implements MenuService {
         }
 
         return Menu.from(menuEntity);
+    }
+
+    @Override
+    public List<Menu> findMenusInCart(List<CartMenu> cartMenus) {
+        List<Long> ids = cartMenus.stream()
+            .map(CartMenu::getMenuId)
+            .toList();
+
+        return menuRepository.findAllById(ids).stream()
+            .map(Menu::from)
+            .toList();
     }
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuServiceImpl.java
@@ -57,12 +57,14 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
-    public void checkAvailability(long menuId) {
-        MenuEntity menuEntity = menuRepository.findById(menuId)
+    public Menu getAvailableMenu(long id) {
+        MenuEntity menuEntity = menuRepository.findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
 
         if(menuEntity.getMenuStatus() != MenuStatus.AVAILABLE){
             throw new CustomException(ErrorCode.MENU_NOT_AVAILABLE);
         }
+
+        return Menu.from(menuEntity);
     }
 }

--- a/src/main/java/ksh/deliveryhub/menu/service/MenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/menu/service/MenuServiceImpl.java
@@ -3,6 +3,7 @@ package ksh.deliveryhub.menu.service;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.menu.entity.MenuEntity;
+import ksh.deliveryhub.menu.entity.MenuStatus;
 import ksh.deliveryhub.menu.model.Menu;
 import ksh.deliveryhub.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
@@ -53,5 +54,15 @@ public class MenuServiceImpl implements MenuService {
         menuRepository.deleteById(id);
 
         return Menu.from(menuEntity);
+    }
+
+    @Override
+    public void checkAvailability(long menuId) {
+        MenuEntity menuEntity = menuRepository.findById(menuId)
+            .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        if(menuEntity.getMenuStatus() != MenuStatus.AVAILABLE){
+            throw new CustomException(ErrorCode.MENU_NOT_AVAILABLE);
+        }
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -2,6 +2,7 @@ store.not.found={0}는 존재하지 않는 가게입니다.
 store.invalid.phone=가게 전화번호 형식이 올바르지 않습니다.
 menu.not.found={0}은 존재하지 않는 메뉴입니다.
 menu.store.id.mismatch=해당 메뉴는 회원님의 가게에 속한 메뉴가 아닙니다.
+menu.option.not.found=존재하지 않는 메뉴 옵션입니다.
 menu.not.available=해당 메뉴는 현재 주문할 수 없습니다.
 menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습니다.
 cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,4 +6,3 @@ menu.option.not.found=존재하지 않는 메뉴 옵션입니다.
 menu.not.available=해당 메뉴는 현재 주문할 수 없습니다.
 menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습니다.
 cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
-cart.menu.not.found.in.cart=장바구니에 추가된 메뉴가 아닙니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,3 +4,5 @@ menu.not.found={0}은 존재하지 않는 메뉴입니다.
 menu.store.id.mismatch=해당 메뉴는 회원님의 가게에 속한 메뉴가 아닙니다.
 menu.not.available=해당 메뉴는 현재 주문할 수 없습니다.
 menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습니다.
+cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
+cart.menu.not.found.in.cart=장바구니에 추가된 메뉴가 아닙니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,3 +6,4 @@ menu.option.not.found=존재하지 않는 메뉴 옵션입니다.
 menu.not.available=해당 메뉴는 현재 주문할 수 없습니다.
 menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습니다.
 cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
+cart.menu.store.conflict=장바구니에 같은 가게의 메뉴만 담을 수 있습니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -2,4 +2,5 @@ store.not.found={0}는 존재하지 않는 가게입니다.
 store.invalid.phone=가게 전화번호 형식이 올바르지 않습니다.
 menu.not.found={0}은 존재하지 않는 메뉴입니다.
 menu.store.id.mismatch=해당 메뉴는 회원님의 가게에 속한 메뉴가 아닙니다.
+menu.not.available=해당 메뉴는 현재 주문할 수 없습니다.
 menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습니다.

--- a/src/test/java/ksh/deliveryhub/cart/api/CartControllerTest.java
+++ b/src/test/java/ksh/deliveryhub/cart/api/CartControllerTest.java
@@ -1,0 +1,117 @@
+package ksh.deliveryhub.cart.api;
+
+import ksh.deliveryhub.cart.entity.CartEntity;
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import ksh.deliveryhub.cart.repository.CartMenuRepository;
+import ksh.deliveryhub.cart.repository.CartRepository;
+import ksh.deliveryhub.menu.entity.MenuEntity;
+import ksh.deliveryhub.menu.entity.MenuOptionEntity;
+import ksh.deliveryhub.menu.repository.MenuOptionRepository;
+import ksh.deliveryhub.menu.repository.MenuRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static ksh.deliveryhub.cart.entity.CartStatus.ACTIVE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CartControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    CartRepository cartRepository;
+
+    @Autowired
+    CartMenuRepository cartMenuRepository;
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    @Autowired
+    MenuOptionRepository menuOptionRepository;
+
+    @Test
+    public void 장바구니에_메뉴를_추가하고_201응답을_받는다() throws Exception {
+        //given
+        //카트 생성
+        CartEntity cartEntity = createCartEntity(1L);
+        cartRepository.save(cartEntity);
+
+        //메뉴 생성
+        MenuEntity menuEntity1 = createMenuEntity("치즈 피자", "치즈 들어감", 10000, 1L);
+        MenuEntity menuEntity2 = createMenuEntity("페퍼로니 피자", "페퍼로니 들어감", 15000, 1L);
+        menuRepository.saveAll(List.of(menuEntity1, menuEntity2));
+
+        //메뉴의 옵션 생성
+        MenuOptionEntity menuOptionEntity = createMenuOptionEntity("치즈 추가", 500, menuEntity1.getId());
+        menuOptionRepository.save(menuOptionEntity);
+
+        //장바구니에 담긴 메뉴 생성
+        CartMenuEntity cartMenuEntity1 = createCartMenuEntity(cartEntity.getId(), menuEntity1.getId(), menuOptionEntity.getId(), 2);
+        CartMenuEntity cartMenuEntity2 = createCartMenuEntity(cartEntity.getId(), menuEntity2.getId(), null, 1);
+        cartMenuRepository.saveAll(List.of(cartMenuEntity1, cartMenuEntity2));
+
+        //when //then
+        mockMvc.perform(
+                get("/carts")
+                    .param("userId", "1")
+            ).andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.menus").isArray())
+            .andExpect(jsonPath("$.data.menus[0].quantity").value(2))
+            .andExpect(jsonPath("$.data.menus[0].menuName").value(menuEntity1.getName()))
+            .andExpect(jsonPath("$.data.menus[0].menuPrice").value(menuEntity1.getPrice()))
+            .andExpect(jsonPath("$.data.menus[0].optionName").value(menuOptionEntity.getName()))
+            .andExpect(jsonPath("$.data.menus[0].optionPrice").value(menuOptionEntity.getPrice()))
+            .andExpect(jsonPath("$.data.menus[1].quantity").value(1))
+            .andExpect(jsonPath("$.data.menus[1].menuName").value(menuEntity2.getName()))
+            .andExpect(jsonPath("$.data.menus[1].menuPrice").value(menuEntity2.getPrice()))
+            .andExpect(jsonPath("$.data.menus[1].optionName").isEmpty())
+            .andExpect(jsonPath("$.data.menus[1].optionPrice").isEmpty());
+    }
+
+    private static CartEntity createCartEntity(long userId) {
+        return CartEntity.builder()
+            .userId(userId)
+            .status(ACTIVE)
+            .build();
+    }
+
+    private static MenuEntity createMenuEntity(String name, String description, int price, long storeId) {
+        return MenuEntity.builder()
+            .name(name)
+            .description(description)
+            .price(price)
+            .storeId(storeId)
+            .image("https://example.com/image.png")
+            .build();
+    }
+
+    private static MenuOptionEntity createMenuOptionEntity(String name, int price, long menuId) {
+        return MenuOptionEntity.builder()
+            .name(name)
+            .price(price)
+            .menuId(menuId)
+            .build();
+    }
+
+    private static CartMenuEntity createCartMenuEntity(long cartId, long menuId, Long optionId, int quantity) {
+        return CartMenuEntity.builder()
+            .cartId(cartId)
+            .menuId(menuId)
+            .optionId(optionId)
+            .quantity(quantity)
+            .build();
+    }
+}

--- a/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
@@ -104,6 +104,61 @@ class CartMenuServiceImplTest {
             .returns(ErrorCode.CART_MENU_STORE_CONFLICT, CustomException::getErrorCode);
     }
 
+    @Test
+    public void 장바구니에_담긴_메뉴의_수량을_변경한다() throws Exception{
+        //given
+        CartMenuEntity cartMenuEntity = createCartMenuEntity(1L, 1L, 3L, 3);
+        cartMenuRepository.save(cartMenuEntity);
+
+        CartMenu cartMenu = CartMenu.builder()
+            .id(cartMenuEntity.getId())
+            .quantity(1)
+            .build();
+
+        //when
+        cartMenuService.changeQuantity(1L, cartMenu);
+
+        //then
+        CartMenuEntity updatedCartMenuEntity = cartMenuRepository.findById(cartMenuEntity.getId()).get();
+        assertThat(updatedCartMenuEntity.getQuantity()).isEqualTo(1);
+    }
+
+    @Test
+    public void 장바구니에_담긴_메뉴의_수량을_변경할_때_수량이_0이면_메뉴를_장바구니에서_삭제한다() throws Exception{
+        //given
+        CartMenuEntity cartMenuEntity = createCartMenuEntity(1L, 1L, 3L, 3);
+        cartMenuRepository.save(cartMenuEntity);
+
+        CartMenu cartMenu = CartMenu.builder()
+            .id(cartMenuEntity.getId())
+            .quantity(0)
+            .build();
+
+        //when
+        cartMenuService.changeQuantity(1L, cartMenu);
+
+        //then
+        boolean exists = cartMenuRepository.existsById(cartMenuEntity.getId());
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    public void 장바구니에_담긴_메뉴의_수량을_변경할_때_사용자의_장바구니에_없는_메뉴는_수량을_변경할_수_없다() throws Exception{
+        //given
+        CartMenuEntity cartMenuEntity = createCartMenuEntity(1L, 1L, 3L, 3);
+        cartMenuRepository.save(cartMenuEntity);
+
+        CartMenu cartMenu = CartMenu.builder()
+            .id(3L)
+            .quantity(1)
+            .build();
+
+        //when //then
+        assertThatExceptionOfType(CustomException.class)
+            .isThrownBy(() -> cartMenuService.changeQuantity(1L, cartMenu))
+            .returns(ErrorCode.CART_MENU_NOT_FOUND, CustomException::getErrorCode);
+    }
+
     private static MenuEntity createMenuEntity(long storeId) {
         return MenuEntity.builder()
             .storeId(storeId)

--- a/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
@@ -1,0 +1,129 @@
+package ksh.deliveryhub.cart.service;
+
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import ksh.deliveryhub.cart.model.CartMenu;
+import ksh.deliveryhub.cart.repository.CartMenuRepository;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.menu.entity.MenuEntity;
+import ksh.deliveryhub.menu.repository.MenuRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@SpringBootTest
+class CartMenuServiceImplTest {
+
+    @Autowired
+    CartMenuServiceImpl cartMenuService;
+
+    @Autowired
+    CartMenuRepository cartMenuRepository;
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    @AfterEach
+    void tearDown() {
+        cartMenuRepository.deleteAllInBatch();
+        menuRepository.deleteAllInBatch();
+    }
+
+    @Test
+    public void 장바구니에_메뉴를_추가할_때_같은_메뉴와_옵션의_품목이_존재하면_수량을_증가시킨다() throws Exception{
+        //given
+        MenuEntity menuEntity = createMenuEntity(1L);
+        menuRepository.save(menuEntity);
+
+        CartMenuEntity existingCartMenuEntity = createCartMenuEntity(1L, menuEntity.getId(), 3L, 3);
+        cartMenuRepository.save(existingCartMenuEntity);
+
+        CartMenu newCartMenu = createCartMenu(menuEntity.getId(), 3L, 2);
+
+        //when
+        CartMenu addedCartMenu = cartMenuService.addCartMenu(1L, newCartMenu, 1L);
+
+        //then
+        assertThat(addedCartMenu.getQuantity()).isEqualTo(5);
+    }
+
+    @Test
+    public void 장바구니에_메뉴를_추가할_때_같은_메뉴와_옵션의_품목이_존재하지_않으면_새로_추가한다() throws Exception{
+        //given
+        MenuEntity menuEntity = createMenuEntity(1L);
+        menuRepository.save(menuEntity);
+
+        CartMenu cartMenu = createCartMenu(menuEntity.getId(), 3L, 2);
+
+        //when
+        CartMenu addedCartMenu = cartMenuService.addCartMenu(1L, cartMenu, 1L);
+
+        //then
+        assertThat(addedCartMenu.getQuantity()).isEqualTo(2);
+    }
+
+    @Test
+    public void 장바구니에_메뉴를_추가할_때_옵션을_선택하지_않은_메뉴도_장바구니에_추가할_수_있다() throws Exception{
+        //given
+        MenuEntity menuEntity = createMenuEntity(1L);
+        menuRepository.save(menuEntity);
+
+        CartMenuEntity existingCartMenuEntity = createCartMenuEntity(1L, menuEntity.getId(), null, 3);
+        cartMenuRepository.save(existingCartMenuEntity);
+
+        CartMenu newCartMenu = createCartMenu(menuEntity.getId(), null, 2);
+
+        //when
+        CartMenu addedCartMenu = cartMenuService.addCartMenu(1L, newCartMenu, 1L);
+
+        //then
+        assertThat(addedCartMenu.getQuantity()).isEqualTo(5);
+    }
+
+    @Test
+    public void 장바구니에_메뉴를_추가할_때_다른_가게의_메뉴가_이미_존재하면_메뉴_추가에_실패한다() throws Exception{
+        //given
+        MenuEntity existingMenuEntity = createMenuEntity(1L);
+        MenuEntity newMenuEntity = createMenuEntity(2L);
+        menuRepository.saveAll(List.of(existingMenuEntity, newMenuEntity));
+
+        CartMenuEntity existingCartMenuEntity = createCartMenuEntity(1L, existingMenuEntity.getId(), 3L, 3);
+        cartMenuRepository.save(existingCartMenuEntity);
+
+        CartMenu newCartMenu = createCartMenu(newMenuEntity.getId(), 43L, 2);
+
+        //when //then
+        assertThatExceptionOfType(CustomException.class)
+            .isThrownBy(() -> cartMenuService.addCartMenu(1L, newCartMenu, newMenuEntity.getStoreId()))
+            .returns(ErrorCode.CART_MENU_STORE_CONFLICT, CustomException::getErrorCode);
+    }
+
+    private static MenuEntity createMenuEntity(long storeId) {
+        return MenuEntity.builder()
+            .storeId(storeId)
+            .build();
+    }
+
+    private static CartMenuEntity createCartMenuEntity(long cartId, long menuId, Long optionId, int quantity) {
+        return CartMenuEntity.builder()
+            .cartId(cartId)
+            .menuId(menuId)
+            .optionId(optionId)
+            .quantity(quantity)
+            .build();
+    }
+
+    private static CartMenu createCartMenu(long menuId, Long optionId, int quantity) {
+        return CartMenu.builder()
+            .menuId(menuId)
+            .optionId(optionId)
+            .quantity(quantity)
+            .build();
+    }
+}


### PR DESCRIPTION
# 📝 주요 구현 사항
## 🛠️ 장바구니 관련 엔티티 설계

- **Cart**: 유저의 장바구니를 나타내는 엔티티입니다.  
  유저는 여러 개의 장바구니를 가질 수 있으며, 실제로 사용하는 것은 활성화된 장바구니 하나입니다.  
  일정 시간 동안 주문으로 전환되지 않으면 만료된다고 가정하며, 이를 위한 `expireAt` 필드가 존재합니다. (자동 만료는 미구현입니다)

- **CartMenu**: 특정 장바구니에 담긴 메뉴입니다.  
  같은 메뉴라도 선택한 옵션이 다르면 다른 품목으로 취급합니다.  
  옵션은 선택하지 않을 수도 있습니다.

## 🛠️ 장바구니에 메뉴 담기

- 유저의 활성 장바구니를 조회합니다.
- 요청한 메뉴가 주문 가능하고, 옵션이 해당 메뉴에 속하는지 검증합니다.
- 장바구니에 이미 담긴 메뉴들의 가게와 요청한 메뉴의 가게가 다르면 거절합니다.
- 같다면:
  - 같은 메뉴·옵션 조합이 있다면 수량을 증가시키고,
  - 없다면 새 품목으로 장바구니에 추가합니다.

## 🛠️ 장바구니 메뉴 수량 변경

- 유저의 **활성 장바구니를 조회**합니다.  
- 요청한 `cartMenu`가 **유저의 장바구니에 존재하는지 검증**합니다.  
- 존재하면 **수량을 변경**하고, 변경된 수량이 0 이하일 경우 **장바구니에서 삭제**합니다.

## 🛠️ 장바구니 메뉴 삭제

- 유저의 **활성 장바구니를 조회**합니다.  
- 요청한 `cartMenu`가 **유저의 장바구니에 존재하는지 검증**합니다.  
- 존재하면 해당 메뉴를 **장바구니에서 삭제**합니다.

## 🛠️ 장바구니 비우기

- 유저의 **활성 장바구니를 조회**합니다.  
- 유저의 장바구니에 담긴 메뉴를 모두 삭제합니다.

## 🛠️ 장바구니 조회
유저의 장바구니를 조회하면, 각 품목에 대해 다음과 같은 정보를 제공합니다:

- 품목 ID  
- 담긴 수량  
- 메뉴 이름, 설명, 가격, 이미지 URL  
- 선택한 옵션 이름 및 가격 (옵션은 선택하지 않았을 수도 있음)

조회 절차는 다음과 같습니다:

1. 유저의 **활성 장바구니를 조회**합니다.  
2. 장바구니에 담긴 **CartMenu 목록을 조회**합니다.  
3. 각 CartMenu에 대해 **대응하는 메뉴(menu)와 옵션(menuOption)** 정보를 조회합니다.  
4. 조회한 메뉴 및 옵션 정보를 **CartMenu와 묶어 응답 형태로 반환**합니다.


---

# 💬 공유 사항

## 📌 유스케이스 테스트 기준

각 유스케이스는 컨트롤러에서 `MockMvc`를 활용해 테스트할 수도 있고, 파사드의 메서드를 직접 테스트할 수도 있습니다.  
현재는 아래와 같은 이유로 컨트롤러에서 통합 테스트로 유스케이스를 테스트하고 있습니다.

- 컨트롤러 테스트를 통해 **요청/응답 바인딩과 로직 검증을 동시에 수행**할 수 있어, 유스케이스 전반을 한 번에 검증할 수 있습니다.
- 파사드에서 로직만 테스트하고, 컨트롤러에서는 Mockito를 활용해 바인딩만 따로 테스트하는 방식도 가능하지만, 이는 **동일 유스케이스에 대해 중복 테스트가 발생**하여 오히려 비용이 증가합니다.
- 바인딩이 단순해 로직만 검증해도 충분한 경우에는 파사드 테스트로도 가능하지만, 바인딩이 중요한 유스케이스가 혼재되어 있을 경우 테스트의 위치가 분산되어 **도메인 흐름을 파악하기 어려워질 수 있습니다.**

이를 통해 테스트 간 중복을 줄이고, 생산성과 효율성 향상에 도움이 될 것으로 생각합니다.

## 📌 장바구니 API에서 cartId 미사용

장바구니 관련 API를 요청할 때 클라이언트가 보낼 요청값으로 cartId를 포함시키지 않았습니다.
이유는 아래와 같습니다.
- 처음 주문하거나 주문을 완료한 유저는 활성된 장바구니가 없을 수 있다.
- 클라이언트가 임의의 cartId를 조작해 보내는 것을 방지하기 위해, 서버에서 인증된 `userId`를 기반으로 `cartId`를 내부적으로 조회합니다.

