### PR TITLE
[#9] 쿠폰 생성 및 사용자 쿠폰 발급·조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    testImplementation 'org.jmock:jmock:2.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/ksh/deliveryhub/common/config/ClockConfig.java
+++ b/src/main/java/ksh/deliveryhub/common/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package ksh.deliveryhub.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode {
     MENU_OPTION_NOT_FOUND(404, "menu.option.not.found"),
     MENU_OPTION_IDS_INVALID(400, "menu.option.ids.invalid"),
     CART_MENU_NOT_FOUND(404, "cart.menu.not.found"),
-    CART_MENU_STORE_CONFLICT(400, "cart.menu.store.conflict");
+    CART_MENU_STORE_CONFLICT(400, "cart.menu.store.conflict"),
+    COUPON_NOT_FOUND(404, "coupon.not.found"),
+    COUPON_OUT_OF_STOCK(400, "coupon.out.of.stock");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     CART_MENU_NOT_FOUND(404, "cart.menu.not.found"),
     CART_MENU_STORE_CONFLICT(400, "cart.menu.store.conflict"),
     COUPON_NOT_FOUND(404, "coupon.not.found"),
-    COUPON_OUT_OF_STOCK(400, "coupon.out.of.stock");
+    COUPON_OUT_OF_STOCK(400, "coupon.out.of.stock"),
+    USER_COUPON_ALREADY_REGISTERED(400, "user.coupon.already.registered");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/util/CouponCodeUtils.java
+++ b/src/main/java/ksh/deliveryhub/common/util/CouponCodeUtils.java
@@ -1,0 +1,14 @@
+package ksh.deliveryhub.common.util;
+
+import java.util.UUID;
+
+public class CouponCodeUtils {
+
+    public static String generateCode() {
+        String uuid = UUID.randomUUID().toString();
+
+        return uuid.replace("-", "")
+            .substring(0, 12)
+            .toUpperCase();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/api/CouponController.java
+++ b/src/main/java/ksh/deliveryhub/coupon/api/CouponController.java
@@ -1,0 +1,34 @@
+package ksh.deliveryhub.coupon.api;
+
+import jakarta.validation.Valid;
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import ksh.deliveryhub.coupon.dto.request.CouponCreateRequestDto;
+import ksh.deliveryhub.coupon.dto.response.CouponResponseDto;
+import ksh.deliveryhub.coupon.facade.CouponFacade;
+import ksh.deliveryhub.coupon.model.Coupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CouponController {
+
+    private final CouponFacade couponFacade;
+
+    @PostMapping("/coupons")
+    public ResponseEntity<SuccessResponseDto> createCoupon(
+        @Valid @RequestBody CouponCreateRequestDto request
+    ) {
+        Coupon coupon = couponFacade.createCoupon(request.toModel());
+        CouponResponseDto couponResponseDto = CouponResponseDto.from(coupon);
+        SuccessResponseDto<CouponResponseDto> response = SuccessResponseDto.of(couponResponseDto);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(response);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/api/UserCouponController.java
+++ b/src/main/java/ksh/deliveryhub/coupon/api/UserCouponController.java
@@ -36,7 +36,7 @@ public class UserCouponController {
         SuccessResponseDto<UserCouponDetailListResponseDto> response = SuccessResponseDto.of(userCouponDetailList);
 
         return ResponseEntity
-            .status(HttpStatus.CREATED)
+            .status(HttpStatus.OK)
             .body(response);
     }
 

--- a/src/main/java/ksh/deliveryhub/coupon/api/UserCouponController.java
+++ b/src/main/java/ksh/deliveryhub/coupon/api/UserCouponController.java
@@ -1,0 +1,54 @@
+package ksh.deliveryhub.coupon.api;
+
+import jakarta.validation.Valid;
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import ksh.deliveryhub.coupon.dto.request.UserCouponQueryRequestDto;
+import ksh.deliveryhub.coupon.dto.response.UserCouponDetailListResponseDto;
+import ksh.deliveryhub.coupon.dto.response.UserCouponDetailResponseDto;
+import ksh.deliveryhub.coupon.facade.CouponFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class UserCouponController {
+
+    private final CouponFacade couponFacade;
+
+    @GetMapping("/users/{userId}/coupons")
+    public ResponseEntity<SuccessResponseDto> findAvailableCouponDetails(
+        @PathVariable("userId") Long userId,
+        @Valid UserCouponQueryRequestDto request
+    ) {
+        List<UserCouponDetailResponseDto> userCouponDetails = couponFacade.findAvailableCouponDetails(userId, request.getFoodCategory())
+            .stream()
+            .map(UserCouponDetailResponseDto::from)
+            .toList();
+
+        UserCouponDetailListResponseDto userCouponDetailList = UserCouponDetailListResponseDto.of(userCouponDetails);
+        SuccessResponseDto<UserCouponDetailListResponseDto> response = SuccessResponseDto.of(userCouponDetailList);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(response);
+    }
+
+    @PostMapping("/users/{userId}/coupons/{code}")
+    public ResponseEntity<SuccessResponseDto> registerCoupon(
+        @PathVariable("userId") Long userId,
+        @PathVariable("code") String code
+    ) {
+        couponFacade.registerUserCoupon(userId, code);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/dto/request/CouponCreateRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/request/CouponCreateRequestDto.java
@@ -1,0 +1,47 @@
+package ksh.deliveryhub.coupon.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponCreateRequestDto {
+
+    @NotBlank(message = "쿠폰 상세 설명은 필수입니다.")
+    private String description;
+
+    @NotNull(message = "쿠폰 할인 가격은 필수입니다.")
+    @Min(value = 1000, message = "쿠폰 할인 가격은 1000원 이상이어야 합니다.")
+    private Integer discountAmount;
+
+    @NotNull(message = "쿠폰 유효 일수는 필수입니다.")
+    @Min(value = 1, message = "쿠폰 유효 일수는 1일 이상이어야 합니다.")
+    private Integer duration;
+
+    private FoodCategory foodCategory;
+
+    @NotNull(message = "쿠폰 발급량은 필수입니다.")
+    @PositiveOrZero(message = "쿠폰 발급량은 양수입니다.")
+    private Integer issueQuantity;
+
+    @NotNull(message = "쿠폰 최소 사용 금액은 필수입니다.")
+    @PositiveOrZero(message = "쿠폰 최소 사용 금액은 양수입니다.")
+    private Integer minimumSpend;
+
+    public Coupon toModel() {
+        return Coupon.builder()
+            .description(description)
+            .discountAmount(discountAmount)
+            .duration(duration)
+            .foodCategory(foodCategory)
+            .remainingQuantity(issueQuantity)
+            .minimumSpend(minimumSpend)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/dto/request/UserCouponQueryRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/request/UserCouponQueryRequestDto.java
@@ -3,8 +3,10 @@ package ksh.deliveryhub.coupon.dto.request;
 import jakarta.validation.constraints.NotNull;
 import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class UserCouponQueryRequestDto {
 
     @NotNull(message = "쿠폰을 적용할 음식 카테고리는 필수입니다.")

--- a/src/main/java/ksh/deliveryhub/coupon/dto/request/UserCouponQueryRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/request/UserCouponQueryRequestDto.java
@@ -1,0 +1,12 @@
+package ksh.deliveryhub.coupon.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import lombok.Getter;
+
+@Getter
+public class UserCouponQueryRequestDto {
+
+    @NotNull(message = "쿠폰을 적용할 음식 카테고리는 필수입니다.")
+    private FoodCategory foodCategory;
+}

--- a/src/main/java/ksh/deliveryhub/coupon/dto/response/CouponResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/response/CouponResponseDto.java
@@ -1,0 +1,33 @@
+package ksh.deliveryhub.coupon.dto.response;
+
+import ksh.deliveryhub.coupon.entity.CouponStatus;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponResponseDto {
+
+    private String code;
+    private String description;
+    private Integer discountAmount;
+    private Integer duration;
+    private FoodCategory foodCategory;
+    private CouponStatus couponStatus;
+    private Integer remainingQuantity;
+    private Integer minimumSpend;
+
+    public static CouponResponseDto from(ksh.deliveryhub.coupon.model.Coupon coupon) {
+        return CouponResponseDto.builder()
+            .code(coupon.getCode())
+            .description(coupon.getDescription())
+            .discountAmount(coupon.getDiscountAmount())
+            .duration(coupon.getDuration())
+            .foodCategory(coupon.getFoodCategory())
+            .couponStatus(coupon.getCouponStatus())
+            .remainingQuantity(coupon.getRemainingQuantity())
+            .minimumSpend(coupon.getMinimumSpend())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/dto/response/UserCouponDetailListResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/response/UserCouponDetailListResponseDto.java
@@ -1,0 +1,17 @@
+package ksh.deliveryhub.coupon.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UserCouponDetailListResponseDto {
+
+    private final List<UserCouponDetailResponseDto> coupons;
+
+    public static UserCouponDetailListResponseDto of(List<UserCouponDetailResponseDto> coupons) {
+        return new UserCouponDetailListResponseDto(coupons);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/dto/response/UserCouponDetailResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/response/UserCouponDetailResponseDto.java
@@ -1,0 +1,36 @@
+package ksh.deliveryhub.coupon.dto.response;
+
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.model.UserCouponDetail;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserCouponDetailResponseDto {
+
+    private String code;
+    private String description;
+    private Integer discountAmount;
+    private LocalDate expireAt;
+    private FoodCategory foodCategory;
+    private Integer minimumSpend;
+
+    public static UserCouponDetailResponseDto from(UserCouponDetail userCouponDetail) {
+        Coupon coupon = userCouponDetail.getCoupon();
+        UserCoupon userCoupon = userCouponDetail.getUserCoupon();
+
+        return UserCouponDetailResponseDto.builder()
+            .code(coupon.getCode())
+            .description(coupon.getDescription())
+            .discountAmount(coupon.getDiscountAmount())
+            .expireAt(userCoupon.getExpireAt())
+            .foodCategory(coupon.getFoodCategory())
+            .minimumSpend(coupon.getMinimumSpend())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
@@ -38,10 +38,10 @@ public class CouponEntity extends BaseEntity {
 
     public void decreaseRemainingQuantity() {
         this.remainingQuantity--;
+    }
 
-        if(this.remainingQuantity <= 0) {
-            this.couponStatus = CouponStatus.INACTIVE;
-        }
+    public void inactive() {
+        this.couponStatus = CouponStatus.INACTIVE;
     }
 
     @Builder

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
@@ -31,6 +31,9 @@ public class CouponEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private FoodCategory foodCategory;
 
+    @Enumerated(EnumType.STRING)
+    private CouponStatus couponStatus;
+
     private Integer issueNumberLimit;
 
     private Integer minimumSpend;
@@ -43,6 +46,7 @@ public class CouponEntity extends BaseEntity {
         Integer discountAmount,
         Integer validDays,
         FoodCategory foodCategory,
+        CouponStatus couponStatus,
         Integer issueNumberLimit,
         Integer minimumSpend
     ) {
@@ -52,6 +56,7 @@ public class CouponEntity extends BaseEntity {
         this.discountAmount = discountAmount;
         this.validDays = validDays;
         this.foodCategory = foodCategory;
+        this.couponStatus = couponStatus;
         this.issueNumberLimit = issueNumberLimit;
         this.minimumSpend = minimumSpend;
     }

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
@@ -36,6 +36,14 @@ public class CouponEntity extends BaseEntity {
 
     private Integer minimumSpend;
 
+    public void decreaseRemainingQuantity() {
+        this.remainingQuantity--;
+
+        if(this.remainingQuantity <= 0) {
+            this.couponStatus = CouponStatus.INACTIVE;
+        }
+    }
+
     @Builder
     private CouponEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
@@ -8,8 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,7 +24,7 @@ public class CouponEntity extends BaseEntity {
 
     private Integer discountAmount;
 
-    private Integer validDays;
+    private Integer duration;
 
     @Enumerated(EnumType.STRING)
     private FoodCategory foodCategory;
@@ -44,7 +42,7 @@ public class CouponEntity extends BaseEntity {
         String code,
         String description,
         Integer discountAmount,
-        Integer validDays,
+        Integer duration,
         FoodCategory foodCategory,
         CouponStatus couponStatus,
         Integer issueNumberLimit,
@@ -54,7 +52,7 @@ public class CouponEntity extends BaseEntity {
         this.code = code;
         this.description = description;
         this.discountAmount = discountAmount;
-        this.validDays = validDays;
+        this.duration = duration;
         this.foodCategory = foodCategory;
         this.couponStatus = couponStatus;
         this.issueNumberLimit = issueNumberLimit;

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEntity.java
@@ -32,7 +32,7 @@ public class CouponEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CouponStatus couponStatus;
 
-    private Integer issueNumberLimit;
+    private Integer remainingQuantity;
 
     private Integer minimumSpend;
 
@@ -45,7 +45,7 @@ public class CouponEntity extends BaseEntity {
         Integer duration,
         FoodCategory foodCategory,
         CouponStatus couponStatus,
-        Integer issueNumberLimit,
+        Integer remainingQuantity,
         Integer minimumSpend
     ) {
         this.id = id;
@@ -55,7 +55,7 @@ public class CouponEntity extends BaseEntity {
         this.duration = duration;
         this.foodCategory = foodCategory;
         this.couponStatus = couponStatus;
-        this.issueNumberLimit = issueNumberLimit;
+        this.remainingQuantity = remainingQuantity;
         this.minimumSpend = minimumSpend;
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponStatus.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponStatus.java
@@ -1,0 +1,6 @@
+package ksh.deliveryhub.coupon.entity;
+
+public enum CouponStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponTransactionEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponTransactionEntity.java
@@ -24,7 +24,7 @@ public class CouponTransactionEntity extends BaseEntity {
 
     private LocalDateTime eventTime;
 
-    private Long couponId;
+    private Long userCouponId;
 
     private Long orderId;
 
@@ -35,14 +35,14 @@ public class CouponTransactionEntity extends BaseEntity {
         Long id,
         CouponEventType eventType,
         LocalDateTime eventTime,
-        Long couponId,
+        Long userCouponId,
         Long orderId,
         Long userId
     ) {
         this.id = id;
         this.eventType = eventType;
         this.eventTime = eventTime;
-        this.couponId = couponId;
+        this.userCouponId = userCouponId;
         this.orderId = orderId;
         this.userId = userId;
     }

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponTransactionEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponTransactionEntity.java
@@ -22,8 +22,6 @@ public class CouponTransactionEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CouponEventType eventType;
 
-    private LocalDateTime eventTime;
-
     private Long userCouponId;
 
     private Long orderId;
@@ -41,7 +39,6 @@ public class CouponTransactionEntity extends BaseEntity {
     ) {
         this.id = id;
         this.eventType = eventType;
-        this.eventTime = eventTime;
         this.userCouponId = userCouponId;
         this.orderId = orderId;
         this.userId = userId;

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
@@ -24,7 +24,7 @@ public class UserCouponEntity extends BaseEntity {
     private Long couponId;
 
     @Enumerated(EnumType.STRING)
-    private CouponStatus couponStatus;
+    private UserCouponStatus couponStatus;
 
     private LocalDateTime expireAt;
 
@@ -33,7 +33,7 @@ public class UserCouponEntity extends BaseEntity {
         Long id,
         Long userId,
         Long couponId,
-        CouponStatus couponStatus,
+        UserCouponStatus couponStatus,
         LocalDateTime expireAt
     ) {
         this.id = id;

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -26,7 +26,7 @@ public class UserCouponEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserCouponStatus couponStatus;
 
-    private LocalDateTime expireAt;
+    private LocalDate expireAt;
 
     @Builder
     private UserCouponEntity(
@@ -34,7 +34,7 @@ public class UserCouponEntity extends BaseEntity {
         Long userId,
         Long couponId,
         UserCouponStatus couponStatus,
-        LocalDateTime expireAt
+        LocalDate expireAt
     ) {
         this.id = id;
         this.userId = userId;

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponStatus.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponStatus.java
@@ -2,5 +2,6 @@ package ksh.deliveryhub.coupon.entity;
 
 public enum UserCouponStatus {
     ACTIVE,
-    EXPIRED
+    EXPIRED,
+    USED
 }

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponStatus.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponStatus.java
@@ -1,6 +1,6 @@
 package ksh.deliveryhub.coupon.entity;
 
-public enum CouponStatus {
+public enum UserCouponStatus {
     ACTIVE,
     EXPIRED
 }

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -21,11 +21,9 @@ public class CouponFacade {
         return couponService.createCoupon(coupon);
     }
 
-    public UserCouponDetail registerUserCoupon(long userId, String code) {
+    public void registerUserCoupon(long userId, String code) {
         Coupon coupon = couponService.issueCoupon(code);
         UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
         couponTransactionService.saveIssueTransaction(userCoupon);
-
-        return UserCouponDetail.of(coupon, userCoupon);
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -1,0 +1,27 @@
+package ksh.deliveryhub.coupon.facade;
+
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.model.UserCouponDetail;
+import ksh.deliveryhub.coupon.service.CouponService;
+import ksh.deliveryhub.coupon.service.CouponTransactionService;
+import ksh.deliveryhub.coupon.service.UserCouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponFacade {
+
+    private final CouponService couponService;
+    private final UserCouponService userCouponService;
+    private final CouponTransactionService couponTransactionService;
+
+    public UserCouponDetail registerUserCoupon(long userId, String code) {
+        Coupon coupon = couponService.issueCoupon(code);
+        UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
+        couponTransactionService.saveIssueTransaction(userCoupon);
+
+        return UserCouponDetail.of(coupon, userCoupon);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -17,6 +17,10 @@ public class CouponFacade {
     private final UserCouponService userCouponService;
     private final CouponTransactionService couponTransactionService;
 
+    public Coupon createCoupon(Coupon coupon) {
+        return couponService.createCoupon(coupon);
+    }
+
     public UserCouponDetail registerUserCoupon(long userId, String code) {
         Coupon coupon = couponService.issueCoupon(code);
         UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -33,7 +33,7 @@ public class CouponFacade {
         couponTransactionService.saveIssueTransaction(userCoupon);
     }
 
-    public List<UserCouponDetail> findAvailableCoupons(long userId, FoodCategory foodCategory) {
+    public List<UserCouponDetail> findAvailableCouponDetails(long userId, FoodCategory foodCategory) {
         List<UserCoupon> availableCoupons = userCouponService.findAvailableCouponsOfUser(userId, foodCategory);
 
         List<Long> ids = availableCoupons.stream()

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -6,8 +6,14 @@ import ksh.deliveryhub.coupon.model.UserCouponDetail;
 import ksh.deliveryhub.coupon.service.CouponService;
 import ksh.deliveryhub.coupon.service.CouponTransactionService;
 import ksh.deliveryhub.coupon.service.UserCouponService;
+import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -25,5 +31,24 @@ public class CouponFacade {
         Coupon coupon = couponService.issueCoupon(code);
         UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
         couponTransactionService.saveIssueTransaction(userCoupon);
+    }
+
+    public List<UserCouponDetail> findAvailableCoupons(long userId, FoodCategory foodCategory) {
+        List<UserCoupon> availableCoupons = userCouponService.findAvailableCouponsOfUser(userId, foodCategory);
+
+        List<Long> ids = availableCoupons.stream()
+            .map(UserCoupon::getId)
+            .toList();
+        List<Coupon> relatedCoupons = couponService.findCouponsByIdsIn(ids);
+
+        Map<Long, UserCoupon> userCouponMap = availableCoupons.stream()
+            .collect(Collectors.toMap(UserCoupon::getCouponId, Function.identity()));
+
+        return relatedCoupons.stream()
+            .map(coupon -> UserCouponDetail.of(
+                coupon,
+                userCouponMap.get(coupon.getId())
+            ))
+            .toList();
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -9,6 +9,7 @@ import ksh.deliveryhub.coupon.service.UserCouponService;
 import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -23,16 +24,19 @@ public class CouponFacade {
     private final UserCouponService userCouponService;
     private final CouponTransactionService couponTransactionService;
 
+    @Transactional
     public Coupon createCoupon(Coupon coupon) {
         return couponService.createCoupon(coupon);
     }
 
+    @Transactional
     public void registerUserCoupon(long userId, String code) {
         Coupon coupon = couponService.issueCoupon(code);
         UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
         couponTransactionService.saveIssueTransaction(userCoupon);
     }
 
+    @Transactional(readOnly = true)
     public List<UserCouponDetail> findAvailableCouponDetails(long userId, FoodCategory foodCategory) {
         List<UserCoupon> availableCoupons = userCouponService.findAvailableCouponsOfUser(userId, foodCategory);
 

--- a/src/main/java/ksh/deliveryhub/coupon/model/Coupon.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/Coupon.java
@@ -17,7 +17,7 @@ public class Coupon {
     private Integer duration;
     private FoodCategory foodCategory;
     private CouponStatus couponStatus;
-    private Integer issueNumberLimit;
+    private Integer remainingQuantity;
     private Integer minimumSpend;
 
     public static Coupon from(CouponEntity couponEntity) {
@@ -29,7 +29,7 @@ public class Coupon {
             .duration(couponEntity.getDuration())
             .foodCategory(couponEntity.getFoodCategory())
             .couponStatus(couponEntity.getCouponStatus())
-            .issueNumberLimit(couponEntity.getIssueNumberLimit())
+            .remainingQuantity(couponEntity.getRemainingQuantity())
             .minimumSpend(couponEntity.getMinimumSpend())
             .build();
     }
@@ -43,7 +43,7 @@ public class Coupon {
             .duration(getDuration())
             .foodCategory(getFoodCategory())
             .couponStatus(getCouponStatus())
-            .issueNumberLimit(getIssueNumberLimit())
+            .remainingQuantity(getRemainingQuantity())
             .minimumSpend(getMinimumSpend())
             .build();
     }

--- a/src/main/java/ksh/deliveryhub/coupon/model/Coupon.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/Coupon.java
@@ -1,0 +1,50 @@
+package ksh.deliveryhub.coupon.model;
+
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.entity.CouponStatus;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Coupon {
+
+    private Long id;
+    private String code;
+    private String description;
+    private Integer discountAmount;
+    private Integer validDays;
+    private FoodCategory foodCategory;
+    private CouponStatus couponStatus;
+    private Integer issueNumberLimit;
+    private Integer minimumSpend;
+
+    public static Coupon from(CouponEntity couponEntity) {
+        return Coupon.builder()
+            .id(couponEntity.getId())
+            .code(couponEntity.getCode())
+            .description(couponEntity.getDescription())
+            .discountAmount(couponEntity.getDiscountAmount())
+            .validDays(couponEntity.getValidDays())
+            .foodCategory(couponEntity.getFoodCategory())
+            .couponStatus(couponEntity.getCouponStatus())
+            .issueNumberLimit(couponEntity.getIssueNumberLimit())
+            .minimumSpend(couponEntity.getMinimumSpend())
+            .build();
+    }
+
+    public CouponEntity toEntity(String code) {
+        return CouponEntity.builder()
+            .id(getId())
+            .code(code)
+            .description(getDescription())
+            .discountAmount(getDiscountAmount())
+            .validDays(getValidDays())
+            .foodCategory(getFoodCategory())
+            .couponStatus(getCouponStatus())
+            .issueNumberLimit(getIssueNumberLimit())
+            .minimumSpend(getMinimumSpend())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/model/Coupon.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/Coupon.java
@@ -14,7 +14,7 @@ public class Coupon {
     private String code;
     private String description;
     private Integer discountAmount;
-    private Integer validDays;
+    private Integer duration;
     private FoodCategory foodCategory;
     private CouponStatus couponStatus;
     private Integer issueNumberLimit;
@@ -26,7 +26,7 @@ public class Coupon {
             .code(couponEntity.getCode())
             .description(couponEntity.getDescription())
             .discountAmount(couponEntity.getDiscountAmount())
-            .validDays(couponEntity.getValidDays())
+            .duration(couponEntity.getDuration())
             .foodCategory(couponEntity.getFoodCategory())
             .couponStatus(couponEntity.getCouponStatus())
             .issueNumberLimit(couponEntity.getIssueNumberLimit())
@@ -40,7 +40,7 @@ public class Coupon {
             .code(code)
             .description(getDescription())
             .discountAmount(getDiscountAmount())
-            .validDays(getValidDays())
+            .duration(getDuration())
             .foodCategory(getFoodCategory())
             .couponStatus(getCouponStatus())
             .issueNumberLimit(getIssueNumberLimit())

--- a/src/main/java/ksh/deliveryhub/coupon/model/CouponTransaction.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/CouponTransaction.java
@@ -1,0 +1,44 @@
+package ksh.deliveryhub.coupon.model;
+
+import ksh.deliveryhub.coupon.entity.CouponEventType;
+import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CouponTransaction {
+
+    private Long id;
+    private CouponEventType eventType;
+    private LocalDateTime eventTime;
+    private Long userCouponId;
+    private Long orderId;
+    private Long userId;
+
+    public static CouponTransaction from(
+        CouponTransactionEntity couponTransactionEntity
+    ) {
+        return CouponTransaction.builder()
+            .id(couponTransactionEntity.getId())
+            .eventType(couponTransactionEntity.getEventType())
+            .eventTime(couponTransactionEntity.getEventTime())
+            .userCouponId(couponTransactionEntity.getUserCouponId())
+            .orderId(couponTransactionEntity.getOrderId())
+            .userId(couponTransactionEntity.getUserId())
+            .build();
+    }
+
+    public CouponTransactionEntity toEntity() {
+        return CouponTransactionEntity.builder()
+            .id(getId())
+            .eventType(getEventType())
+            .eventTime(getEventTime())
+            .userCouponId(getUserCouponId())
+            .orderId(getOrderId())
+            .userId(getUserId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/model/CouponTransaction.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/CouponTransaction.java
@@ -13,7 +13,6 @@ public class CouponTransaction {
 
     private Long id;
     private CouponEventType eventType;
-    private LocalDateTime eventTime;
     private Long userCouponId;
     private Long orderId;
     private Long userId;
@@ -24,7 +23,6 @@ public class CouponTransaction {
         return CouponTransaction.builder()
             .id(couponTransactionEntity.getId())
             .eventType(couponTransactionEntity.getEventType())
-            .eventTime(couponTransactionEntity.getEventTime())
             .userCouponId(couponTransactionEntity.getUserCouponId())
             .orderId(couponTransactionEntity.getOrderId())
             .userId(couponTransactionEntity.getUserId())
@@ -35,7 +33,6 @@ public class CouponTransaction {
         return CouponTransactionEntity.builder()
             .id(getId())
             .eventType(getEventType())
-            .eventTime(getEventTime())
             .userCouponId(getUserCouponId())
             .orderId(getOrderId())
             .userId(getUserId())

--- a/src/main/java/ksh/deliveryhub/coupon/model/UserCoupon.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/UserCoupon.java
@@ -5,7 +5,7 @@ import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -15,7 +15,7 @@ public class UserCoupon {
     private Long userId;
     private Long couponId;
     private UserCouponStatus couponStatus;
-    private LocalDateTime expireAt;
+    private LocalDate expireAt;
 
     public static UserCoupon from(UserCouponEntity userCouponEntity) {
         return UserCoupon.builder()

--- a/src/main/java/ksh/deliveryhub/coupon/model/UserCoupon.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/UserCoupon.java
@@ -1,0 +1,39 @@
+package ksh.deliveryhub.coupon.model;
+
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserCoupon {
+
+    private Long id;
+    private Long userId;
+    private Long couponId;
+    private UserCouponStatus couponStatus;
+    private LocalDateTime expireAt;
+
+    public static UserCoupon from(UserCouponEntity userCouponEntity) {
+        return UserCoupon.builder()
+            .id(userCouponEntity.getId())
+            .userId(userCouponEntity.getUserId())
+            .couponId(userCouponEntity.getCouponId())
+            .couponStatus(userCouponEntity.getCouponStatus())
+            .expireAt(userCouponEntity.getExpireAt())
+            .build();
+    }
+
+    public UserCouponEntity toEntity() {
+        return UserCouponEntity.builder()
+            .id(getId())
+            .userId(getUserId())
+            .couponId(getCouponId())
+            .couponStatus(getCouponStatus())
+            .expireAt(getExpireAt())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/model/UserCouponDetail.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/UserCouponDetail.java
@@ -1,0 +1,19 @@
+package ksh.deliveryhub.coupon.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserCouponDetail {
+
+    private Coupon coupon;
+    private UserCoupon userCoupon;
+
+    public static UserCouponDetail of(Coupon coupon, UserCoupon userCoupon) {
+        return UserCouponDetail.builder()
+            .coupon(coupon)
+            .userCoupon(userCoupon)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/CouponRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/CouponRepository.java
@@ -1,7 +1,14 @@
 package ksh.deliveryhub.coupon.repository;
 
+import jakarta.persistence.LockModeType;
 import ksh.deliveryhub.coupon.entity.CouponEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<CouponEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CouponEntity> findByCode(String code);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/CouponRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.coupon.repository;
+
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<CouponEntity, Long> {
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/CouponTransactionRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/CouponTransactionRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.coupon.repository;
+
+import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponTransactionRepository extends JpaRepository<CouponTransactionEntity, Long> {
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
@@ -1,0 +1,11 @@
+package ksh.deliveryhub.coupon.repository;
+
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.store.entity.FoodCategory;
+
+import java.util.List;
+
+public interface UserCouponQueryRepository {
+
+    List<UserCouponEntity> findApplicableCoupons(long userId, FoodCategory foodCategory);
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
@@ -1,0 +1,36 @@
+package ksh.deliveryhub.coupon.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static ksh.deliveryhub.coupon.entity.QCouponEntity.couponEntity;
+import static ksh.deliveryhub.coupon.entity.QUserCouponEntity.userCouponEntity;
+
+@RequiredArgsConstructor
+public class UserCouponQueryRepositoryImpl implements UserCouponQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserCouponEntity> findApplicableCoupons(long userId, FoodCategory foodCategory) {
+        BooleanExpression foodCategoryEquals = foodCategory == null ? null : couponEntity.foodCategory.eq(foodCategory);
+
+        return queryFactory
+            .select(userCouponEntity)
+            .from(userCouponEntity)
+            .join(couponEntity)
+            .on(userCouponEntity.couponId.eq(couponEntity.id))
+            .where(
+                userCouponEntity.userId.eq(userId),
+                userCouponEntity.couponStatus.eq(UserCouponStatus.ACTIVE),
+                foodCategoryEquals
+            )
+            .fetch();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.coupon.repository;
+
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCouponRepository extends JpaRepository<UserCouponEntity, Long> {
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponRepository.java
@@ -3,5 +3,8 @@ package ksh.deliveryhub.coupon.repository;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserCouponRepository extends JpaRepository<UserCouponEntity, Long>, UserCouponQueryRepository {
+    Optional<UserCouponEntity> findByUserIdAndCouponId(long userId, long couponId);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponRepository.java
@@ -3,5 +3,5 @@ package ksh.deliveryhub.coupon.repository;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserCouponRepository extends JpaRepository<UserCouponEntity, Long> {
+public interface UserCouponRepository extends JpaRepository<UserCouponEntity, Long>, UserCouponQueryRepository {
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
@@ -2,9 +2,13 @@ package ksh.deliveryhub.coupon.service;
 
 import ksh.deliveryhub.coupon.model.Coupon;
 
+import java.util.List;
+
 public interface CouponService {
 
     Coupon createCoupon(Coupon coupon);
 
     Coupon issueCoupon(String code);
+
+    List<Coupon> findCouponsByIdsIn(List<Long> ids);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
@@ -5,4 +5,6 @@ import ksh.deliveryhub.coupon.model.Coupon;
 public interface CouponService {
 
     Coupon createCoupon(Coupon coupon);
+
+    Coupon issueCoupon(String code);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
@@ -1,0 +1,8 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.coupon.model.Coupon;
+
+public interface CouponService {
+
+    Coupon createCoupon(Coupon coupon);
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -41,4 +41,11 @@ public class CouponServiceImpl implements CouponService {
 
         return Coupon.from(couponRepository.save(couponEntity));
     }
+
+    @Override
+    public List<Coupon> findCouponsByIdsIn(List<Long> ids) {
+        return couponRepository.findAllById(ids).stream()
+            .map(Coupon::from)
+            .toList();
+    }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -1,0 +1,23 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.common.util.CouponCodeUtils;
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponServiceImpl implements CouponService {
+
+    private CouponRepository couponRepository;
+
+    @Override
+    public Coupon createCoupon(Coupon coupon) {
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity savedCouponEntity = couponRepository.save(coupon.toEntity(code));
+
+        return Coupon.from(savedCouponEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -1,13 +1,19 @@
 package ksh.deliveryhub.coupon.service;
 
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.common.util.CouponCodeUtils;
 import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.entity.CouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.repository.CouponRepository;
 import lombok.Builder;
-import lombok.Getter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Getter
+import java.util.List;
+
+@Service
 @Builder
 public class CouponServiceImpl implements CouponService {
 
@@ -19,5 +25,20 @@ public class CouponServiceImpl implements CouponService {
         CouponEntity savedCouponEntity = couponRepository.save(coupon.toEntity(code));
 
         return Coupon.from(savedCouponEntity);
+    }
+
+    @Transactional
+    @Override
+    public Coupon issueCoupon(String code) {
+        CouponEntity couponEntity = couponRepository.findByCode(code)
+            .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND, List.of(code)));
+
+        if(couponEntity.getCouponStatus() == CouponStatus.INACTIVE) {
+            throw new CustomException(ErrorCode.COUPON_OUT_OF_STOCK);
+        }
+
+        couponEntity.decreaseRemainingQuantity();
+
+        return Coupon.from(couponRepository.save(couponEntity));
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -7,17 +7,17 @@ import ksh.deliveryhub.coupon.entity.CouponEntity;
 import ksh.deliveryhub.coupon.entity.CouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.repository.CouponRepository;
-import lombok.Builder;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
-@Builder
+@RequiredArgsConstructor
 public class CouponServiceImpl implements CouponService {
 
-    private CouponRepository couponRepository;
+    private final CouponRepository couponRepository;
 
     @Override
     public Coupon createCoupon(Coupon coupon) {

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -39,6 +39,10 @@ public class CouponServiceImpl implements CouponService {
 
         couponEntity.decreaseRemainingQuantity();
 
+        if(couponEntity.getRemainingQuantity() == 0) {
+            couponEntity.inactive();
+        }
+
         return Coupon.from(couponRepository.save(couponEntity));
     }
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionService.java
@@ -1,0 +1,9 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.coupon.model.CouponTransaction;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+
+public interface CouponTransactionService {
+
+    CouponTransaction saveIssueTransaction(UserCoupon userCoupon);
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
@@ -6,9 +6,9 @@ import ksh.deliveryhub.coupon.model.CouponTransaction;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.repository.CouponTransactionRepository;
 import lombok.Builder;
-import lombok.Getter;
+import org.springframework.stereotype.Service;
 
-@Getter
+@Service
 @Builder
 public class CouponTransactionServiceImpl implements CouponTransactionService {
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
@@ -5,11 +5,11 @@ import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
 import ksh.deliveryhub.coupon.model.CouponTransaction;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.repository.CouponTransactionRepository;
-import lombok.Builder;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@Builder
+@RequiredArgsConstructor
 public class CouponTransactionServiceImpl implements CouponTransactionService {
 
     private final CouponTransactionRepository couponTransactionRepository;

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
@@ -1,0 +1,27 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.coupon.entity.CouponEventType;
+import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
+import ksh.deliveryhub.coupon.model.CouponTransaction;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.repository.CouponTransactionRepository;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CouponTransactionServiceImpl implements CouponTransactionService {
+
+    private final CouponTransactionRepository couponTransactionRepository;
+
+    @Override
+    public CouponTransaction saveIssueTransaction(UserCoupon userCoupon) {
+        CouponTransactionEntity couponTransactionEntity = CouponTransactionEntity.builder()
+            .userCouponId(userCoupon.getId())
+            .eventType(CouponEventType.ISSUED)
+            .build();
+        couponTransactionRepository.save(couponTransactionEntity);
+
+        return CouponTransaction.from(couponTransactionEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -1,0 +1,9 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+
+public interface UserCouponService {
+
+    UserCoupon registerCoupon(long userId, Coupon coupon);
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -2,8 +2,13 @@ package ksh.deliveryhub.coupon.service;
 
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.store.entity.FoodCategory;
+
+import java.util.List;
 
 public interface UserCouponService {
 
     UserCoupon registerCoupon(long userId, Coupon coupon);
+
+    List<UserCoupon> findAvailableCouponsOfUser(long userId, FoodCategory foodCategory);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -11,7 +11,8 @@ import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -19,6 +20,7 @@ import java.util.List;
 public class UserCouponServiceImpl implements UserCouponService {
 
     private final UserCouponRepository userCouponRepository;
+    private final Clock clock;
 
     @Override
     public UserCoupon registerCoupon(long userId, Coupon coupon) {
@@ -29,7 +31,7 @@ public class UserCouponServiceImpl implements UserCouponService {
 
 
         Integer duration = coupon.getDuration();
-        LocalDateTime expireAt = LocalDateTime.now().plusDays(duration);
+        LocalDate expireAt = LocalDate.now(clock).plusDays(duration);
 
         UserCouponEntity userCouponEntity = UserCouponEntity.builder()
             .couponStatus(UserCouponStatus.ACTIVE)

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -1,0 +1,34 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class UserCouponServiceImpl implements UserCouponService{
+
+    private final UserCouponRepository userCouponRepository;
+
+    @Override
+    public UserCoupon registerCoupon(long userId, Coupon coupon) {
+        Integer duration = coupon.getValidDays();
+        LocalDateTime expireAt = LocalDateTime.now().plusDays(duration);
+
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .couponStatus(UserCouponStatus.ACTIVE)
+            .userId(userId)
+            .couponId(coupon.getId())
+            .expireAt(expireAt)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        return UserCoupon.from(userCouponEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -1,5 +1,7 @@
 package ksh.deliveryhub.coupon.service;
 
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
@@ -20,6 +22,12 @@ public class UserCouponServiceImpl implements UserCouponService {
 
     @Override
     public UserCoupon registerCoupon(long userId, Coupon coupon) {
+        userCouponRepository.findByUserIdAndCouponId(userId, coupon.getId())
+            .ifPresent(userCouponEntity ->
+                {throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);}
+            );
+
+
         Integer duration = coupon.getDuration();
         LocalDateTime expireAt = LocalDateTime.now().plusDays(duration);
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -5,12 +5,12 @@ import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.repository.UserCouponRepository;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
-@Getter
+@Service
 @RequiredArgsConstructor
 public class UserCouponServiceImpl implements UserCouponService{
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -18,7 +18,7 @@ public class UserCouponServiceImpl implements UserCouponService{
 
     @Override
     public UserCoupon registerCoupon(long userId, Coupon coupon) {
-        Integer duration = coupon.getValidDays();
+        Integer duration = coupon.getDuration();
         LocalDateTime expireAt = LocalDateTime.now().plusDays(duration);
 
         UserCouponEntity userCouponEntity = UserCouponEntity.builder()

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -5,14 +5,16 @@ import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class UserCouponServiceImpl implements UserCouponService{
+public class UserCouponServiceImpl implements UserCouponService {
 
     private final UserCouponRepository userCouponRepository;
 
@@ -30,5 +32,16 @@ public class UserCouponServiceImpl implements UserCouponService{
         userCouponRepository.save(userCouponEntity);
 
         return UserCoupon.from(userCouponEntity);
+    }
+
+    @Override
+    public List<UserCoupon> findAvailableCouponsOfUser(long userId, FoodCategory foodCategory) {
+        return userCouponRepository.findApplicableCoupons(
+                userId,
+                foodCategory
+            )
+            .stream()
+            .map(UserCoupon::from)
+            .toList();
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -7,3 +7,4 @@ menu.not.available=해당 메뉴는 현재 주문할 수 없습니다.
 menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습니다.
 cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
 cart.menu.store.conflict=장바구니에 같은 가게의 메뉴만 담을 수 있습니다.
+coupon.not.found={0}는 존재하지 않는 쿠폰입니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -8,3 +8,4 @@ menu.option.ids.invalid=유효하지 않은 메뉴 옵션이 포함되어 있습
 cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
 cart.menu.store.conflict=장바구니에 같은 가게의 메뉴만 담을 수 있습니다.
 coupon.not.found={0}는 존재하지 않는 쿠폰입니다.
+user.coupon.already.registered=이미 등록한 쿠폰입니다.

--- a/src/test/java/ksh/deliveryhub/coupon/api/CouponControllerTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/api/CouponControllerTest.java
@@ -1,0 +1,33 @@
+package ksh.deliveryhub.coupon.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CouponControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    UserCouponRepository userCouponRepository;
+
+    @Test
+    public void 유저가_코드로_쿠폰을_등록하고_201응답을_받는다() throws Exception {
+        //given
+
+    }
+}

--- a/src/test/java/ksh/deliveryhub/coupon/api/UserCouponControllerTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/api/UserCouponControllerTest.java
@@ -1,0 +1,165 @@
+package ksh.deliveryhub.coupon.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.common.util.CouponCodeUtils;
+import ksh.deliveryhub.coupon.dto.response.UserCouponDetailListResponseDto;
+import ksh.deliveryhub.coupon.dto.response.UserCouponDetailResponseDto;
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.entity.CouponStatus;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static ksh.deliveryhub.coupon.entity.UserCouponStatus.ACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserCouponControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    UserCouponRepository userCouponRepository;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+        userCouponRepository.deleteAllInBatch();
+    }
+
+    @Test
+    public void 유저가_코드로_쿠폰을_등록하고_201응답을_받는다() throws Exception {
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 1, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        //when
+        mockMvc.perform(
+                post("/users/{userId}/coupons/{code}", 1L, code)
+            )
+            .andDo(print())
+            .andExpect(status().isCreated());
+
+        //then
+        CouponEntity issuedCouponEntity = couponRepository.findById(couponEntity.getId()).get();
+        assertThat(issuedCouponEntity.getRemainingQuantity()).isEqualTo(0);
+        assertThat(issuedCouponEntity.getCouponStatus()).isEqualTo(CouponStatus.INACTIVE);
+
+        UserCouponEntity registeredUserCouponEntity = userCouponRepository
+            .findByUserIdAndCouponId(1L, couponEntity.getId()).get();
+        assertThat(registeredUserCouponEntity.getCouponId()).isEqualTo(couponEntity.getId());
+        assertThat(registeredUserCouponEntity.getCouponStatus()).isEqualTo(ACTIVE);
+    }
+
+    @Test
+    public void 유저가_쿠폰을_중복_발행하면_400응답을_받는다() throws Exception {
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 1000, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        UserCouponEntity userCouponEntity = createUserCouponEntity(1L, couponEntity.getId());
+        userCouponRepository.save(userCouponEntity);
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(
+                post("/users/{userId}/coupons/{code}", 1L, code)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        // then
+        CustomException ex = (CustomException) mvcResult.getResolvedException();
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.USER_COUPON_ALREADY_REGISTERED);
+    }
+
+    @Test
+    public void 유저가_사용_가능한_쿠폰을_조회하고_200응답을_받는다() throws Exception{
+        //given
+        String code1 = CouponCodeUtils.generateCode();
+        String code2 = CouponCodeUtils.generateCode();
+
+        CouponEntity couponEntity1 = createCouponEntity(code1, 1, FoodCategory.PIZZA);
+        CouponEntity couponEntity2 = createCouponEntity(code2, 1, FoodCategory.PIZZA);
+        CouponEntity couponEntity3 = createCouponEntity(code2, 1, FoodCategory.CHICKEN);
+        couponRepository.saveAll(List.of(couponEntity1, couponEntity2, couponEntity3));
+
+        UserCouponEntity userCouponEntity1 = createUserCouponEntity(1L, couponEntity1.getId());
+        UserCouponEntity userCouponEntity2 = createUserCouponEntity(1L, couponEntity2.getId());
+        userCouponRepository.saveAll(List.of(userCouponEntity1, userCouponEntity2));
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(
+                get("/users/{userId}/coupons", 1L)
+                    .param("foodCategory", FoodCategory.PIZZA.name())
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn();
+
+        //then
+        String json = mvcResult.getResponse().getContentAsString();
+        var response = objectMapper.readValue(
+                json,
+                new TypeReference<SuccessResponseDto<UserCouponDetailListResponseDto>>() {}
+            );
+
+        var content = response.getData().getCoupons();
+        assertThat(content).hasSize(2)
+            .extracting("code", "foodCategory")
+            .containsExactlyInAnyOrder(
+                tuple(code1, FoodCategory.PIZZA),
+                tuple(code2, FoodCategory.PIZZA)
+            );
+    }
+
+    private static CouponEntity createCouponEntity(String code, int remainingQuantity, FoodCategory foodCategory) {
+        return CouponEntity.builder()
+            .code(code)
+            .description("쿠폰")
+            .discountAmount(1000)
+            .duration(1)
+            .foodCategory(foodCategory)
+            .couponStatus(CouponStatus.ACTIVE)
+            .remainingQuantity(remainingQuantity)
+            .minimumSpend(10000)
+            .build();
+    }
+
+    private static UserCouponEntity createUserCouponEntity(long userId, long couponId) {
+        return UserCouponEntity.builder()
+            .userId(userId)
+            .couponId(couponId)
+            .couponStatus(ACTIVE)
+            .build();
+    }
+}

--- a/src/test/java/ksh/deliveryhub/coupon/service/CouponServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/service/CouponServiceImplTest.java
@@ -1,0 +1,99 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.common.util.CouponCodeUtils;
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import org.jmock.lib.concurrent.Blitzer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static ksh.deliveryhub.coupon.entity.CouponStatus.ACTIVE;
+import static ksh.deliveryhub.coupon.entity.CouponStatus.INACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CouponServiceImplTest {
+
+    @Autowired
+    CouponService couponService;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+    }
+
+    @Test
+    public void 요청한_코드로_쿠폰을_발행하면_남은_수량이_1_감소한다() throws Exception {
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 10, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        //when
+        couponService.issueCoupon(code);
+
+        //then
+        CouponEntity decreasedCouponEntity = couponRepository.findById(couponEntity.getId()).get();
+        assertThat(decreasedCouponEntity.getRemainingQuantity()).isEqualTo(9);
+    }
+
+    @Test
+    public void 쿠폰을_발행하고_남은_수량이_0이_되면_쿠폰을_비활성화한다() throws Exception {
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 1, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        //when
+        couponService.issueCoupon(code);
+
+        //then
+        CouponEntity decreasedCouponEntity = couponRepository.findById(couponEntity.getId()).get();
+        assertThat(decreasedCouponEntity.getCouponStatus()).isEqualTo(INACTIVE);
+    }
+
+    @Test
+    public void 여러_유저가_동시에_요청했을_때_쿠폰_수가_부족하면_더_이상_발행하지_않는다() throws Exception{
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 95, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        Blitzer blitzer = new Blitzer(100, 1);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        //when
+        blitzer.blitz(
+            () -> {
+                try {
+                    couponService.issueCoupon(code);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                }
+            }
+        );
+
+        //then
+        assertThat(successCount.get()).isEqualTo(95);
+        assertThat(failureCount.get()).isEqualTo(5);
+    }
+
+    private static CouponEntity createCouponEntity(String code, int remainingQuantity, FoodCategory foodCategory) {
+        return CouponEntity.builder()
+            .code(code)
+            .remainingQuantity(remainingQuantity)
+            .couponStatus(ACTIVE)
+            .foodCategory(foodCategory)
+            .build();
+    }
+}

--- a/src/test/java/ksh/deliveryhub/coupon/service/UserCouponServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/service/UserCouponServiceImplTest.java
@@ -1,0 +1,135 @@
+package ksh.deliveryhub.coupon.service;
+
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static ksh.deliveryhub.coupon.entity.UserCouponStatus.ACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@SuppressWarnings("removal")
+class UserCouponServiceImplTest {
+
+    @Autowired
+    UserCouponService userCouponService;
+
+    @Autowired
+    UserCouponRepository userCouponRepository;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @MockBean
+    Clock clock;
+
+    @AfterEach
+    void tearDown() {
+        userCouponRepository.deleteAllInBatch();
+    }
+
+    @Test
+    public void 유저가_쿠폰을_등록한다() throws Exception {
+        //given
+        Coupon coupon = Coupon.builder()
+            .id(1L)
+            .duration(10)
+            .build();
+
+        Instant fixedInstant = Instant.parse("2025-05-02T00:05:15Z");
+        ZoneId zone = ZoneId.of("Asia/Seoul");
+
+        given(clock.instant()).willReturn(fixedInstant);
+        given(clock.getZone()).willReturn(zone);
+
+        LocalDate expireAt = LocalDate.of(2025, 5, 12);
+
+        //when
+        UserCoupon registeredCoupon = userCouponService.registerCoupon(1L, coupon);
+
+        //then
+        UserCouponEntity userCouponEntity = userCouponRepository.findById(registeredCoupon.getId()).get();
+        assertThat(userCouponEntity.getUserId()).isEqualTo(1L);
+        assertThat(userCouponEntity.getCouponId()).isEqualTo(1L);
+        assertThat(userCouponEntity.getCouponStatus()).isEqualTo(ACTIVE);
+        assertThat(userCouponEntity.getExpireAt()).isEqualTo(expireAt);
+    }
+
+    @Test
+    public void 사용자가_이미_등록한_쿠폰을_다시_등록하려_하면_예외가_발생한다() throws Exception {
+        //given
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .userId(1L)
+            .couponId(1L)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        Coupon coupon = Coupon.builder()
+            .id(1L)
+            .duration(10)
+            .build();
+
+
+        //when //then
+        assertThatExceptionOfType(CustomException.class)
+            .isThrownBy(() -> userCouponService.registerCoupon(1L, coupon))
+            .returns(ErrorCode.USER_COUPON_ALREADY_REGISTERED, CustomException::getErrorCode);
+    }
+
+    @Test
+    public void 적용_가능한_음식_카테고리를_지정하지_않으면_사용_가능한_모든_쿠폰을_조회한다() throws Exception {
+        //given
+        CouponEntity couponEntity1 = CouponEntity.builder()
+            .foodCategory(FoodCategory.PIZZA)
+            .build();
+
+        CouponEntity couponEntity2 = CouponEntity.builder()
+            .foodCategory(FoodCategory.CHICKEN)
+            .build();
+        couponRepository.saveAll(List.of(couponEntity1, couponEntity2));
+
+        UserCouponEntity userCouponEntity1 = UserCouponEntity.builder()
+            .userId(1L)
+            .couponId(couponEntity1.getId())
+            .couponStatus(ACTIVE)
+            .build();
+
+        UserCouponEntity userCouponEntity2 = UserCouponEntity.builder()
+            .userId(1L)
+            .couponId(couponEntity2.getId())
+            .couponStatus(ACTIVE)
+            .build();
+        userCouponRepository.saveAll(List.of(userCouponEntity1, userCouponEntity2));
+
+        //when
+        List<UserCoupon> userCoupons = userCouponService.findAvailableCouponsOfUser(1L, null);
+
+        //then
+        assertThat(userCoupons).hasSize(2)
+            .extracting("userId", "couponId")
+            .containsExactlyInAnyOrder(
+                tuple(1L, couponEntity1.getId()),
+                tuple(1L, couponEntity2.getId())
+            );
+    }
+}


### PR DESCRIPTION
# 📝 주요 구현 사항

## 🛠️ 쿠폰 생성

- 관리자가 쿠폰을 생성할 수 있습니다.
- 관리자는 다음 정보를 요청 시 전달해야 합니다:
  - `description`: 쿠폰 상세 설명
  - `discountAmount`: 할인 금액
  - `duration`: 쿠폰 유효 기간(일 단위)
  - `foodCategory`: 적용 가능한 음식 카테고리 (제한이 없다면 생략 가능)
  - `issueQuantity`: 발급 수량
  - `minimumSpend`: 쿠폰 적용 최소 주문 금액
- 쿠폰 코드는 내부적으로 UUID의 앞 12자리로 생성됩니다.
- 응답 시 쿠폰 ID 대신 보안을 위해 쿠폰 코드를 반환합니다.

## 🛠️ 유저 쿠폰 등록

- 유저가 쿠폰 코드를 이용해 쿠폰을 등록할 수 있습니다.
- 이미 등록한 쿠폰은 중복 등록이 불가능합니다.
- 모두 소진된 쿠폰은 발급할 수 없습니다.
- 마지막 쿠폰이 발급되면 해당 쿠폰은 비활성화됩니다.
- 쿠폰이 등록되면 발급 이력이 로그로 기록됩니다.

## 🛠️ 유저 쿠폰 조회

- 유저는 특정 음식 카테고리에 적용 가능한 쿠폰을 조회할 수 있습니다.
- 카테고리를 지정하지 않으면 사용 가능한 모든 쿠폰을 조회합니다.

---

# 💬 공유 사항

## 📌 유저 쿠폰 유효 기간 만료 처리 미적용

현재는 유저 쿠폰의 유효 기간이 지나도 만료 처리를 하지 않습니다.  
스케줄러를 이용해 정기적으로 만료 처리를 수행해야 하지만,  
만료 대상 쿠폰을 조회해 메모리에 적재하는 방식은 비효율적일 수 있다 생각했고
적절한 처리 방식을 확정하지 못해 아직 구현하지 않았습니다.

## 📌 쿠폰 발급 시 동시성 문제 대응

다수의 유저가 동시에 쿠폰을 발급하는 상황에서도 정확성을 보장하기 위해  
현재는 비관적 락을 적용한 상태입니다.  
성능 저하 가능성이 있어 추후 더 나은 동시성 제어 방식으로 개선할 예정입니다.
