### PR TITLE
[#13] 장바구니 기반 주문 생성 기능 구현

### DIFF
--- a/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
@@ -2,6 +2,7 @@ package ksh.deliveryhub.cart.model;
 
 import com.querydsl.core.annotations.QueryProjection;
 import ksh.deliveryhub.menu.entity.MenuStatus;
+import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -19,6 +20,7 @@ public class CartMenuDetail {
     private Integer menuPrice;
     private String image;
     private Long storeId;
+    private FoodCategory foodCategory;
 
     private Long optionId;
     private String optionName;

--- a/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
+++ b/src/main/java/ksh/deliveryhub/cart/model/CartMenuDetail.java
@@ -23,4 +23,9 @@ public class CartMenuDetail {
     private Long optionId;
     private String optionName;
     private Integer optionPrice;
+
+    public int getTotalPrice() {
+        int optionPrice = optionId != null ? this.optionPrice : 0;
+        return (menuPrice + optionPrice) * quantity;
+    }
 }

--- a/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/repository/CartMenuQueryRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import ksh.deliveryhub.cart.entity.CartMenuEntity;
 import ksh.deliveryhub.cart.model.CartMenuDetail;
 import ksh.deliveryhub.cart.model.QCartMenuDetail;
+import ksh.deliveryhub.store.entity.QStoreEntity;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.Optional;
 import static ksh.deliveryhub.cart.entity.QCartMenuEntity.cartMenuEntity;
 import static ksh.deliveryhub.menu.entity.QMenuEntity.menuEntity;
 import static ksh.deliveryhub.menu.entity.QMenuOptionEntity.menuOptionEntity;
+import static ksh.deliveryhub.store.entity.QStoreEntity.*;
 
 @RequiredArgsConstructor
 public class CartMenuQueryRepositoryImpl implements CartMenuQueryRepository {
@@ -52,26 +54,32 @@ public class CartMenuQueryRepositoryImpl implements CartMenuQueryRepository {
     @Override
     public List<CartMenuDetail> findCartMenusWithDetail(long cartId) {
         return queryFactory
-            .select(new QCartMenuDetail(
-                cartMenuEntity.id,
-                cartMenuEntity.quantity,
-
-                menuEntity.id,
-                menuEntity.name,
-                menuEntity.description,
-                menuEntity.menuStatus,
-                menuEntity.price,
-                menuEntity.image,
-                menuEntity.storeId,
-
-                menuOptionEntity.id,
-                menuOptionEntity.name,
-                menuOptionEntity.price
-            ))
+            .select(projectCartMenuDetail())
             .from(cartMenuEntity)
             .join(menuEntity).on(cartMenuEntity.menuId.eq(menuEntity.id))
+            .join(storeEntity).on(menuEntity.storeId.eq(storeEntity.id))
             .leftJoin(menuOptionEntity).on(cartMenuEntity.optionId.eq(menuOptionEntity.id))
             .where(cartMenuEntity.cartId.eq(cartId))
             .fetch();
+    }
+
+    private static QCartMenuDetail projectCartMenuDetail() {
+        return new QCartMenuDetail(
+            cartMenuEntity.id,
+            cartMenuEntity.quantity,
+
+            menuEntity.id,
+            menuEntity.name,
+            menuEntity.description,
+            menuEntity.menuStatus,
+            menuEntity.price,
+            menuEntity.image,
+            menuEntity.storeId,
+            storeEntity.foodCategory,
+
+            menuOptionEntity.id,
+            menuOptionEntity.name,
+            menuOptionEntity.price
+        );
     }
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuService.java
@@ -16,4 +16,6 @@ public interface CartMenuService {
     void clearCartMenuOfUser(long cartId);
 
     List<CartMenuDetail> findCartMenusWithDetail(long cartId);
+
+    List<CartMenuDetail> checkCartMenuBeforeOrder(long cartId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -78,7 +78,7 @@ public class CartMenuServiceImpl implements CartMenuService {
     @Override
     public List<CartMenuDetail> checkCartMenuBeforeOrder(long cartId) {
         List<CartMenuDetail> cartMenuDetails = cartMenuRepository.findCartMenusWithDetail(cartId);
-\
+
         for (CartMenuDetail cartMenuDetail : cartMenuDetails) {
             if(cartMenuDetail.getMenuStatus() != MenuStatus.AVAILABLE) {
                 throw new CustomException(ErrorCode.MENU_NOT_AVAILABLE);

--- a/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartMenuServiceImpl.java
@@ -6,6 +6,7 @@ import ksh.deliveryhub.cart.model.CartMenuDetail;
 import ksh.deliveryhub.cart.repository.CartMenuRepository;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.menu.entity.MenuStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,5 +73,21 @@ public class CartMenuServiceImpl implements CartMenuService {
     @Override
     public List<CartMenuDetail> findCartMenusWithDetail(long cartId) {
         return cartMenuRepository.findCartMenusWithDetail(cartId);
+    }
+
+    @Override
+    public List<CartMenuDetail> checkCartMenuBeforeOrder(long cartId) {
+        List<CartMenuDetail> cartMenuDetails = cartMenuRepository.findCartMenusWithDetail(cartId);
+\
+        for (CartMenuDetail cartMenuDetail : cartMenuDetails) {
+            if(cartMenuDetail.getMenuStatus() != MenuStatus.AVAILABLE) {
+                throw new CustomException(ErrorCode.MENU_NOT_AVAILABLE);
+            }
+        }
+        if(cartMenuDetails.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_EMPTY);
+        }
+
+        return cartMenuDetails;
     }
 }

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
     COUPON_NOT_FOUND(404, "coupon.not.found"),
     COUPON_OUT_OF_STOCK(400, "coupon.out.of.stock"),
     USER_COUPON_ALREADY_REGISTERED(400, "user.coupon.already.registered"),
-    USER_COUPON_NOT_USABLE(400, "user.coupon.not.usable");
+    USER_COUPON_NOT_USABLE(400, "user.coupon.not.usable"),
+    USER_POINT_NOT_FOUND(404, "user.point.not.found"),
+    USER_POINT_NOT_ENOUGH(400, "user.point.not.enough");
+
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     CART_MENU_STORE_CONFLICT(400, "cart.menu.store.conflict"),
     COUPON_NOT_FOUND(404, "coupon.not.found"),
     COUPON_OUT_OF_STOCK(400, "coupon.out.of.stock"),
-    USER_COUPON_ALREADY_REGISTERED(400, "user.coupon.already.registered");
+    USER_COUPON_ALREADY_REGISTERED(400, "user.coupon.already.registered"),
+    USER_COUPON_NOT_USABLE(400, "user.coupon.not.usable");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     USER_COUPON_ALREADY_REGISTERED(400, "user.coupon.already.registered"),
     USER_COUPON_NOT_USABLE(400, "user.coupon.not.usable"),
     USER_POINT_NOT_FOUND(404, "user.point.not.found"),
-    USER_POINT_NOT_ENOUGH(400, "user.point.not.enough");
+    USER_POINT_NOT_ENOUGH(400, "user.point.not.enough"),
+    CART_EMPTY(400, "cart.empty");
 
 
     private final int status;

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
@@ -28,6 +28,10 @@ public class UserCouponEntity extends BaseEntity {
 
     private LocalDate expireAt;
 
+    public void reserve() {
+        this.couponStatus = UserCouponStatus.RESERVED;
+    }
+
     @Builder
     private UserCouponEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponStatus.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponStatus.java
@@ -3,5 +3,6 @@ package ksh.deliveryhub.coupon.entity;
 public enum UserCouponStatus {
     ACTIVE,
     EXPIRED,
-    USED
+    USED,
+    RESERVED
 }

--- a/src/main/java/ksh/deliveryhub/coupon/model/UserCouponDetail.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/UserCouponDetail.java
@@ -2,14 +2,17 @@ package ksh.deliveryhub.coupon.model;
 
 import com.querydsl.core.annotations.QueryProjection;
 import ksh.deliveryhub.coupon.entity.CouponStatus;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @Getter
+@Builder
 @AllArgsConstructor(onConstructor = @__(@QueryProjection))
 public class UserCouponDetail {
 
@@ -27,4 +30,17 @@ public class UserCouponDetail {
     private CouponStatus couponStatus;
     private Integer remainingQuantity;
     private Integer minimumSpend;
+
+    public static UserCouponDetail of(
+        UserCouponEntity userCouponEntity,
+        int discountAmount
+    ) {
+        return UserCouponDetail.builder()
+            .id(userCouponEntity.getId())
+            .userId(userCouponEntity.getUserId())
+            .userCouponStatus(userCouponEntity.getCouponStatus())
+            .expireAt(userCouponEntity.getExpireAt())
+            .discountAmount(discountAmount)
+            .build();
+    }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/model/UserCouponDetail.java
+++ b/src/main/java/ksh/deliveryhub/coupon/model/UserCouponDetail.java
@@ -43,4 +43,10 @@ public class UserCouponDetail {
             .discountAmount(discountAmount)
             .build();
     }
+
+    public static UserCouponDetail empty() {
+        return UserCouponDetail.builder()
+            .discountAmount(0)
+            .build();
+    }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
@@ -1,11 +1,15 @@
 package ksh.deliveryhub.coupon.repository;
 
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
 import ksh.deliveryhub.store.entity.FoodCategory;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserCouponQueryRepository {
 
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
+
+    Optional<UserCouponEntity> findAvailableCouponByIdAndUserId(long id, long userId);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
@@ -1,6 +1,6 @@
 package ksh.deliveryhub.coupon.repository;
 
-import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import com.querydsl.core.Tuple;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
 import ksh.deliveryhub.store.entity.FoodCategory;
 
@@ -11,5 +11,5 @@ public interface UserCouponQueryRepository {
 
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
 
-    Optional<UserCouponEntity> findAvailableCouponByIdAndUserId(long id, long userId);
+    Optional<Tuple> findCouponToApply(long id, long userId, FoodCategory foodCategory);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package ksh.deliveryhub.coupon.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.QUserCouponDetail;
@@ -42,13 +43,13 @@ public class UserCouponQueryRepositoryImpl implements UserCouponQueryRepository 
         UserCouponEntity userCoupon = queryFactory
             .select(userCouponEntity)
             .from(userCouponEntity)
-            .join(couponEntity)
-            .on(userCouponEntity.couponId.eq(couponEntity.id))
+            .join(couponEntity).on(userCouponEntity.couponId.eq(couponEntity.id))
             .where(
                 userCouponEntity.id.eq(id),
                 userCouponEntity.userId.eq(userId),
                 userCouponEntity.couponStatus.eq(UserCouponStatus.ACTIVE)
             )
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetchOne();
 
         return Optional.ofNullable(userCoupon);

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
 import static ksh.deliveryhub.coupon.entity.QCouponEntity.couponEntity;
 import static ksh.deliveryhub.coupon.entity.QUserCouponEntity.userCouponEntity;
@@ -24,22 +25,7 @@ public class UserCouponQueryRepositoryImpl implements UserCouponQueryRepository 
         BooleanExpression foodCategoryEquals = foodCategory == null ? null : couponEntity.foodCategory.eq(foodCategory);
 
         return queryFactory
-            .select(new QUserCouponDetail(
-                userCouponEntity.id,
-                userCouponEntity.userId,
-                userCouponEntity.couponStatus,
-                userCouponEntity.expireAt,
-
-                couponEntity.id,
-                couponEntity.code,
-                couponEntity.description,
-                couponEntity.discountAmount,
-                couponEntity.duration,
-                couponEntity.foodCategory,
-                couponEntity.couponStatus,
-                couponEntity.remainingQuantity,
-                couponEntity.minimumSpend
-            ))
+            .select(projectUserCouponDetail())
             .from(userCouponEntity)
             .join(couponEntity)
             .on(userCouponEntity.couponId.eq(couponEntity.id))
@@ -49,5 +35,41 @@ public class UserCouponQueryRepositoryImpl implements UserCouponQueryRepository 
                 foodCategoryEquals
             )
             .fetch();
+    }
+
+    @Override
+    public Optional<UserCouponEntity> findAvailableCouponByIdAndUserId(long id, long userId) {
+        UserCouponEntity userCoupon = queryFactory
+            .select(userCouponEntity)
+            .from(userCouponEntity)
+            .join(couponEntity)
+            .on(userCouponEntity.couponId.eq(couponEntity.id))
+            .where(
+                userCouponEntity.id.eq(id),
+                userCouponEntity.userId.eq(userId),
+                userCouponEntity.couponStatus.eq(UserCouponStatus.ACTIVE)
+            )
+            .fetchOne();
+
+        return Optional.ofNullable(userCoupon);
+    }
+
+    private static QUserCouponDetail projectUserCouponDetail() {
+        return new QUserCouponDetail(
+            userCouponEntity.id,
+            userCouponEntity.userId,
+            userCouponEntity.couponStatus,
+            userCouponEntity.expireAt,
+
+            couponEntity.id,
+            couponEntity.code,
+            couponEntity.description,
+            couponEntity.discountAmount,
+            couponEntity.duration,
+            couponEntity.foodCategory,
+            couponEntity.couponStatus,
+            couponEntity.remainingQuantity,
+            couponEntity.minimumSpend
+        );
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
@@ -1,9 +1,9 @@
 package ksh.deliveryhub.coupon.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
-import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.QUserCouponDetail;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
@@ -39,20 +39,21 @@ public class UserCouponQueryRepositoryImpl implements UserCouponQueryRepository 
     }
 
     @Override
-    public Optional<UserCouponEntity> findAvailableCouponByIdAndUserId(long id, long userId) {
-        UserCouponEntity userCoupon = queryFactory
-            .select(userCouponEntity)
+    public Optional<Tuple> findCouponToApply(long id, long userId, FoodCategory foodCategory) {
+        Tuple tuple = queryFactory
+            .select(userCouponEntity, couponEntity.discountAmount)
             .from(userCouponEntity)
             .join(couponEntity).on(userCouponEntity.couponId.eq(couponEntity.id))
             .where(
                 userCouponEntity.id.eq(id),
                 userCouponEntity.userId.eq(userId),
-                userCouponEntity.couponStatus.eq(UserCouponStatus.ACTIVE)
+                userCouponEntity.couponStatus.eq(UserCouponStatus.ACTIVE),
+                couponEntity.foodCategory.eq(foodCategory)
             )
             .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetchOne();
 
-        return Optional.ofNullable(userCoupon);
+        return Optional.ofNullable(tuple);
     }
 
     private static QUserCouponDetail projectUserCouponDetail() {

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
@@ -7,6 +7,4 @@ public interface CouponService {
     Coupon createCoupon(Coupon coupon);
 
     Coupon issueCoupon(String code);
-
-    Coupon getById(long id);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponService.java
@@ -2,13 +2,11 @@ package ksh.deliveryhub.coupon.service;
 
 import ksh.deliveryhub.coupon.model.Coupon;
 
-import java.util.List;
-
 public interface CouponService {
 
     Coupon createCoupon(Coupon coupon);
 
     Coupon issueCoupon(String code);
 
-    List<Coupon> findCouponsByIdsIn(List<Long> ids);
+    Coupon getById(long id);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -45,12 +45,4 @@ public class CouponServiceImpl implements CouponService {
 
         return Coupon.from(couponRepository.save(couponEntity));
     }
-
-    @Override
-    public Coupon getById(long id) {
-        CouponEntity couponEntity = couponRepository.findById(id)
-            .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
-
-        return Coupon.from(couponEntity);
-    }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponServiceImpl.java
@@ -47,9 +47,10 @@ public class CouponServiceImpl implements CouponService {
     }
 
     @Override
-    public List<Coupon> findCouponsByIdsIn(List<Long> ids) {
-        return couponRepository.findAllById(ids).stream()
-            .map(Coupon::from)
-            .toList();
+    public Coupon getById(long id) {
+        CouponEntity couponEntity = couponRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+        return Coupon.from(couponEntity);
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -12,4 +12,6 @@ public interface UserCouponService {
     UserCoupon registerCoupon(long userId, Coupon coupon);
 
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
+
+    UserCoupon reserveCoupon(long id, long userId);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -13,5 +13,5 @@ public interface UserCouponService {
 
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
 
-    UserCouponDetail reserveCoupon(long id, long userId, FoodCategory foodCategory);
+    UserCouponDetail reserveCoupon(Long id, long userId, FoodCategory foodCategory);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -13,5 +13,5 @@ public interface UserCouponService {
 
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
 
-    UserCoupon reserveCoupon(long id, long userId);
+    UserCouponDetail reserveCoupon(long id, long userId, FoodCategory foodCategory);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -49,4 +49,14 @@ public class UserCouponServiceImpl implements UserCouponService {
     public List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory) {
         return userCouponRepository.findAvailableCouponsWithDetail(userId, foodCategory);
     }
+
+    @Override
+    public UserCoupon reserveCoupon(long id, long userId) {
+        UserCouponEntity userCouponEntity = userCouponRepository.findAvailableCouponByIdAndUserId(id, userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_COUPON_NOT_USABLE));
+
+        userCouponEntity.reserve();
+
+        return UserCoupon.from(userCouponEntity);
+    }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.coupon.service;
 
+import com.querydsl.core.Tuple;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
@@ -51,12 +52,15 @@ public class UserCouponServiceImpl implements UserCouponService {
     }
 
     @Override
-    public UserCoupon reserveCoupon(long id, long userId) {
-        UserCouponEntity userCouponEntity = userCouponRepository.findAvailableCouponByIdAndUserId(id, userId)
+    public UserCouponDetail reserveCoupon(long id, long userId, FoodCategory foodCategory) {
+        Tuple tuple = userCouponRepository.findCouponToApply(id, userId, foodCategory)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COUPON_NOT_USABLE));
 
+        UserCouponEntity userCouponEntity = tuple.get(0, UserCouponEntity.class);
         userCouponEntity.reserve();
 
-        return UserCoupon.from(userCouponEntity);
+        int discountAmount = tuple.get(1, Integer.class);
+
+        return UserCouponDetail.of(userCouponEntity, discountAmount);
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -12,6 +12,7 @@ import ksh.deliveryhub.coupon.repository.UserCouponRepository;
 import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -51,6 +52,7 @@ public class UserCouponServiceImpl implements UserCouponService {
         return userCouponRepository.findAvailableCouponsWithDetail(userId, foodCategory);
     }
 
+    @Transactional
     @Override
     public UserCouponDetail reserveCoupon(long id, long userId, FoodCategory foodCategory) {
         Tuple tuple = userCouponRepository.findCouponToApply(id, userId, foodCategory)

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -54,7 +54,11 @@ public class UserCouponServiceImpl implements UserCouponService {
 
     @Transactional
     @Override
-    public UserCouponDetail reserveCoupon(long id, long userId, FoodCategory foodCategory) {
+    public UserCouponDetail reserveCoupon(Long id, long userId, FoodCategory foodCategory) {
+        if(id == null) {
+            return UserCouponDetail.empty();
+        }
+
         Tuple tuple = userCouponRepository.findCouponToApply(id, userId, foodCategory)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_COUPON_NOT_USABLE));
 

--- a/src/main/java/ksh/deliveryhub/order/api/OrderController.java
+++ b/src/main/java/ksh/deliveryhub/order/api/OrderController.java
@@ -27,7 +27,7 @@ public class OrderController {
         Order order = orderFacade.placeOrder(
             userId,
             request.getUserCouponId(),
-            request.getPointToUse()
+            request.getPointToUse() != null ? request.getPointToUse() : 0
         );
 
         OrderCreateResponseDto responseDto = OrderCreateResponseDto.from(order);

--- a/src/main/java/ksh/deliveryhub/order/api/OrderController.java
+++ b/src/main/java/ksh/deliveryhub/order/api/OrderController.java
@@ -1,0 +1,40 @@
+package ksh.deliveryhub.order.api;
+
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import ksh.deliveryhub.order.dto.request.OrderCreateRequestDto;
+import ksh.deliveryhub.order.dto.response.OrderCreateResponseDto;
+import ksh.deliveryhub.order.facade.OrderFacade;
+import ksh.deliveryhub.order.model.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderFacade orderFacade;
+
+    @PostMapping("/users/{userId}/orders")
+    public ResponseEntity<SuccessResponseDto> placeOrder(
+        @PathVariable("userId") long userId,
+        @RequestBody OrderCreateRequestDto request
+    ) {
+        Order order = orderFacade.placeOrder(
+            userId,
+            request.getUserCouponId(),
+            request.getPointToUse()
+        );
+
+        OrderCreateResponseDto responseDto = OrderCreateResponseDto.from(order);
+        SuccessResponseDto<OrderCreateResponseDto> response = SuccessResponseDto.of(responseDto);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(response);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/order/dto/request/OrderCreateRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/order/dto/request/OrderCreateRequestDto.java
@@ -1,8 +1,10 @@
 package ksh.deliveryhub.order.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class OrderCreateRequestDto {
 
     private Long userCouponId;

--- a/src/main/java/ksh/deliveryhub/order/dto/request/OrderCreateRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/order/dto/request/OrderCreateRequestDto.java
@@ -1,0 +1,11 @@
+package ksh.deliveryhub.order.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OrderCreateRequestDto {
+
+    private Long userCouponId;
+
+    private Integer pointToUse;
+}

--- a/src/main/java/ksh/deliveryhub/order/dto/response/OrderCreateResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/order/dto/response/OrderCreateResponseDto.java
@@ -14,7 +14,7 @@ public class OrderCreateResponseDto {
     public static OrderCreateResponseDto from(Order order) {
         return OrderCreateResponseDto.builder()
             .id(order.getId())
-            .totalPrice(order.getTotalPrice())
+            .totalPrice(order.getFinalPrice())
             .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/order/dto/response/OrderCreateResponseDto.java
+++ b/src/main/java/ksh/deliveryhub/order/dto/response/OrderCreateResponseDto.java
@@ -1,0 +1,20 @@
+package ksh.deliveryhub.order.dto.response;
+
+import ksh.deliveryhub.order.model.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderCreateResponseDto {
+
+    private long id;
+    private int totalPrice;
+
+    public static OrderCreateResponseDto from(Order order) {
+        return OrderCreateResponseDto.builder()
+            .id(order.getId())
+            .totalPrice(order.getTotalPrice())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/order/entity/OrderEntity.java
+++ b/src/main/java/ksh/deliveryhub/order/entity/OrderEntity.java
@@ -19,6 +19,12 @@ public class OrderEntity extends BaseEntity {
 
     private Integer totalPrice;
 
+    private Integer discountAmount;
+
+    private Integer usedPoint;
+
+    private Integer finalPrice;
+
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
@@ -32,6 +38,9 @@ public class OrderEntity extends BaseEntity {
     private OrderEntity(
         Long id,
         Integer totalPrice,
+        Integer discountAmount,
+        Integer usedPoint,
+        Integer finalPrice,
         OrderStatus orderStatus,
         Long userId,
         Long storeId,
@@ -39,6 +48,9 @@ public class OrderEntity extends BaseEntity {
     ) {
         this.id = id;
         this.totalPrice = totalPrice;
+        this.discountAmount = discountAmount;
+        this.usedPoint = usedPoint;
+        this.finalPrice = finalPrice;
         this.orderStatus = orderStatus;
         this.userId = userId;
         this.storeId = storeId;

--- a/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
+++ b/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
@@ -4,14 +4,14 @@ import ksh.deliveryhub.cart.model.Cart;
 import ksh.deliveryhub.cart.model.CartMenuDetail;
 import ksh.deliveryhub.cart.service.CartMenuService;
 import ksh.deliveryhub.cart.service.CartService;
-import ksh.deliveryhub.coupon.model.Coupon;
-import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.model.UserCouponDetail;
 import ksh.deliveryhub.coupon.service.CouponService;
 import ksh.deliveryhub.coupon.service.UserCouponService;
 import ksh.deliveryhub.order.model.Order;
 import ksh.deliveryhub.order.service.OrderItemService;
 import ksh.deliveryhub.order.service.OrderService;
 import ksh.deliveryhub.point.service.UserPointService;
+import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,22 +27,36 @@ public class OrderFacade {
     private final UserCouponService userCouponService;
     private final UserPointService userPointService;
     private final CartService cartService;
-    private final CouponService couponService;
 
     public Order placeOrder(long userId, long userCouponId, int pointToUse) {
+        //장바구니 조회 및 검증
         Cart cart = cartService.getUserCart(userId);
         List<CartMenuDetail> cartMenuDetails = cartMenuService.checkCartMenuBeforeOrder(cart.getId());
 
-        UserCoupon userCoupon = userCouponService.reserveCoupon(userId, userCouponId);
-        Coupon coupon = couponService.getById(userCoupon.getCouponId());
+        //사용할 쿠폰 검증 및 예약
+        FoodCategory foodCategory = cartMenuDetails.getFirst().getFoodCategory();
+        UserCouponDetail userCouponDetail = userCouponService.reserveCoupon(
+            userId,
+            userCouponId,
+            foodCategory
+        );
+
+        //사용할 포인트 검증
         userPointService.checkBalanceBeforeOrder(userId, pointToUse);
 
+        //주문 생성
         Long storeId = cartMenuDetails.getFirst().getStoreId();
         int totalPrice = cartMenuDetails.stream()
             .mapToInt(CartMenuDetail::getTotalPrice)
             .sum();
+        Order order = orderService.createOrder(
+            userId,
+            storeId,
+            totalPrice,
+            userCouponDetail.getDiscountAmount(),
+            pointToUse
+        );
 
-        Order order = orderService.createOrder(userId, storeId, totalPrice, coupon.getDiscountAmount(), pointToUse);
         orderItemService.createOrderItems(order.getId(), cartMenuDetails);
 
         return order;

--- a/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
+++ b/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
@@ -5,7 +5,6 @@ import ksh.deliveryhub.cart.model.CartMenuDetail;
 import ksh.deliveryhub.cart.service.CartMenuService;
 import ksh.deliveryhub.cart.service.CartService;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
-import ksh.deliveryhub.coupon.service.CouponService;
 import ksh.deliveryhub.coupon.service.UserCouponService;
 import ksh.deliveryhub.order.model.Order;
 import ksh.deliveryhub.order.service.OrderItemService;
@@ -14,6 +13,7 @@ import ksh.deliveryhub.point.service.UserPointService;
 import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -28,6 +28,7 @@ public class OrderFacade {
     private final UserPointService userPointService;
     private final CartService cartService;
 
+    @Transactional
     public Order placeOrder(long userId, long userCouponId, int pointToUse) {
         //장바구니 조회 및 검증
         Cart cart = cartService.getUserCart(userId);

--- a/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
+++ b/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
@@ -29,7 +29,7 @@ public class OrderFacade {
     private final CartService cartService;
 
     @Transactional
-    public Order placeOrder(long userId, long userCouponId, int pointToUse) {
+    public Order placeOrder(long userId, Long userCouponId, int pointToUse) {
         //장바구니 조회 및 검증
         Cart cart = cartService.getUserCart(userId);
         List<CartMenuDetail> cartMenuDetails = cartMenuService.checkCartMenuBeforeOrder(cart.getId());
@@ -37,8 +37,8 @@ public class OrderFacade {
         //사용할 쿠폰 검증 및 예약
         FoodCategory foodCategory = cartMenuDetails.getFirst().getFoodCategory();
         UserCouponDetail userCouponDetail = userCouponService.reserveCoupon(
-            userId,
             userCouponId,
+            userId,
             foodCategory
         );
 

--- a/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
+++ b/src/main/java/ksh/deliveryhub/order/facade/OrderFacade.java
@@ -1,0 +1,50 @@
+package ksh.deliveryhub.order.facade;
+
+import ksh.deliveryhub.cart.model.Cart;
+import ksh.deliveryhub.cart.model.CartMenuDetail;
+import ksh.deliveryhub.cart.service.CartMenuService;
+import ksh.deliveryhub.cart.service.CartService;
+import ksh.deliveryhub.coupon.model.Coupon;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.service.CouponService;
+import ksh.deliveryhub.coupon.service.UserCouponService;
+import ksh.deliveryhub.order.model.Order;
+import ksh.deliveryhub.order.service.OrderItemService;
+import ksh.deliveryhub.order.service.OrderService;
+import ksh.deliveryhub.point.service.UserPointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OrderFacade {
+
+    private final OrderService orderService;
+    private final OrderItemService orderItemService;
+    private final CartMenuService cartMenuService;
+    private final UserCouponService userCouponService;
+    private final UserPointService userPointService;
+    private final CartService cartService;
+    private final CouponService couponService;
+
+    public Order placeOrder(long userId, long userCouponId, int pointToUse) {
+        Cart cart = cartService.getUserCart(userId);
+        List<CartMenuDetail> cartMenuDetails = cartMenuService.checkCartMenuBeforeOrder(cart.getId());
+
+        UserCoupon userCoupon = userCouponService.reserveCoupon(userId, userCouponId);
+        Coupon coupon = couponService.getById(userCoupon.getCouponId());
+        userPointService.checkBalanceBeforeOrder(userId, pointToUse);
+
+        Long storeId = cartMenuDetails.getFirst().getStoreId();
+        int totalPrice = cartMenuDetails.stream()
+            .mapToInt(CartMenuDetail::getTotalPrice)
+            .sum();
+
+        Order order = orderService.createOrder(userId, storeId, totalPrice, coupon.getDiscountAmount(), pointToUse);
+        orderItemService.createOrderItems(order.getId(), cartMenuDetails);
+
+        return order;
+    }
+}

--- a/src/main/java/ksh/deliveryhub/order/model/Order.java
+++ b/src/main/java/ksh/deliveryhub/order/model/Order.java
@@ -1,0 +1,49 @@
+package ksh.deliveryhub.order.model;
+
+import ksh.deliveryhub.order.entity.OrderEntity;
+import ksh.deliveryhub.order.entity.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Order {
+
+    private Long id;
+    private Integer totalPrice;
+    private Integer discountAmount;
+    private Integer usedPoint;
+    private Integer finalPrice;
+    private OrderStatus orderStatus;
+    private Long userId;
+    private Long storeId;
+    private Long riderId;
+
+    public static Order from(OrderEntity orderEntity) {
+        return Order.builder()
+            .id(orderEntity.getId())
+            .totalPrice(orderEntity.getTotalPrice())
+            .discountAmount(orderEntity.getDiscountAmount())
+            .usedPoint(orderEntity.getUsedPoint())
+            .finalPrice(orderEntity.getFinalPrice())
+            .orderStatus(orderEntity.getOrderStatus())
+            .userId(orderEntity.getUserId())
+            .storeId(orderEntity.getStoreId())
+            .riderId(orderEntity.getRiderId())
+            .build();
+    }
+
+    public OrderEntity toEntity() {
+        return OrderEntity.builder()
+            .id(getId())
+            .totalPrice(getTotalPrice())
+            .discountAmount(getDiscountAmount())
+            .usedPoint(getUsedPoint())
+            .finalPrice(getFinalPrice())
+            .orderStatus(getOrderStatus())
+            .userId(getUserId())
+            .storeId(getStoreId())
+            .riderId(getRiderId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/order/model/OrderItem.java
+++ b/src/main/java/ksh/deliveryhub/order/model/OrderItem.java
@@ -1,0 +1,54 @@
+package ksh.deliveryhub.order.model;
+
+import ksh.deliveryhub.cart.model.CartMenuDetail;
+import ksh.deliveryhub.order.entity.OrderItemEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderItem {
+
+    private Long id;
+    private Integer quantity;
+    private Integer menuPrice;
+    private Integer optionPrice;
+    private Long orderId;
+    private Long menuId;
+    private Long optionId;
+
+    public static OrderItem from(long orderId, CartMenuDetail cartMenuDetail) {
+        return OrderItem.builder()
+            .quantity(cartMenuDetail.getQuantity())
+            .menuPrice(cartMenuDetail.getMenuPrice())
+            .optionPrice(cartMenuDetail.getOptionPrice())
+            .orderId(orderId)
+            .menuId(cartMenuDetail.getMenuId())
+            .optionId(cartMenuDetail.getOptionId())
+            .build();
+    }
+
+    public static OrderItem from(OrderItemEntity orderItemEntity) {
+        return OrderItem.builder()
+            .id(orderItemEntity.getId())
+            .quantity(orderItemEntity.getQuantity())
+            .menuPrice(orderItemEntity.getMenuPrice())
+            .optionPrice(orderItemEntity.getOptionPrice())
+            .orderId(orderItemEntity.getOrderId())
+            .menuId(orderItemEntity.getMenuId())
+            .optionId(orderItemEntity.getOptionId())
+            .build();
+    }
+
+    public OrderItemEntity toEntity() {
+        return OrderItemEntity.builder()
+            .id(getId())
+            .quantity(getQuantity())
+            .menuPrice(getMenuPrice())
+            .optionPrice(getOptionPrice())
+            .orderId(getOrderId())
+            .menuId(getMenuId())
+            .optionId(getOptionId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/order/repository/OrderItemRepository.java
+++ b/src/main/java/ksh/deliveryhub/order/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.order.repository;
+
+import ksh.deliveryhub.order.entity.OrderItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItemEntity, Long> {
+}

--- a/src/main/java/ksh/deliveryhub/order/repository/OrderRepository.java
+++ b/src/main/java/ksh/deliveryhub/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.order.repository;
+
+import ksh.deliveryhub.order.entity.OrderEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
+}

--- a/src/main/java/ksh/deliveryhub/order/service/OrderItemService.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderItemService.java
@@ -1,0 +1,11 @@
+package ksh.deliveryhub.order.service;
+
+import ksh.deliveryhub.cart.model.CartMenuDetail;
+import ksh.deliveryhub.order.model.OrderItem;
+
+import java.util.List;
+
+public interface OrderItemService {
+
+    List<OrderItem> createOrderItems(long orderId, List<CartMenuDetail> cartMenuDetails);
+}

--- a/src/main/java/ksh/deliveryhub/order/service/OrderItemServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderItemServiceImpl.java
@@ -1,0 +1,29 @@
+package ksh.deliveryhub.order.service;
+
+import ksh.deliveryhub.cart.model.CartMenuDetail;
+import ksh.deliveryhub.order.entity.OrderItemEntity;
+import ksh.deliveryhub.order.model.OrderItem;
+import ksh.deliveryhub.order.repository.OrderItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderItemServiceImpl implements OrderItemService{
+
+    private final OrderItemRepository orderItemRepository;
+
+    @Override
+    public List<OrderItem> createOrderItems(long orderId, List<CartMenuDetail> cartMenuDetails) {
+        List<OrderItemEntity> orderItemEntities = cartMenuDetails.stream()
+            .map(cartMenuDetail -> OrderItem.from(orderId, cartMenuDetail))
+            .map(OrderItem::toEntity)
+            .toList();
+
+        return orderItemRepository.saveAll(orderItemEntities).stream()
+            .map(OrderItem::from)
+            .toList();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/order/service/OrderService.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderService.java
@@ -1,0 +1,8 @@
+package ksh.deliveryhub.order.service;
+
+import ksh.deliveryhub.order.model.Order;
+
+public interface OrderService {
+
+    Order createOrder(long userId, long storeId, int totalPrice, int discountAmount, int usedPoint);
+}

--- a/src/main/java/ksh/deliveryhub/order/service/OrderServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderServiceImpl.java
@@ -1,0 +1,34 @@
+package ksh.deliveryhub.order.service;
+
+import ksh.deliveryhub.order.entity.OrderEntity;
+import ksh.deliveryhub.order.entity.OrderStatus;
+import ksh.deliveryhub.order.model.Order;
+import ksh.deliveryhub.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService{
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public Order createOrder(long userId, long storeId, int totalPrice, int discountAmount, int usedPoint) {
+        final int finalPrice = totalPrice - discountAmount - usedPoint;
+
+        OrderEntity orderEntity = OrderEntity.builder()
+            .totalPrice(totalPrice)
+            .discountAmount(discountAmount)
+            .usedPoint(usedPoint)
+            .finalPrice(finalPrice)
+            .orderStatus(OrderStatus.PENDING)
+            .userId(userId)
+            .storeId(storeId)
+            .build();
+
+        OrderEntity savedOrderEntity = orderRepository.save(orderEntity);
+
+        return Order.from(savedOrderEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/point/model/UserPoint.java
+++ b/src/main/java/ksh/deliveryhub/point/model/UserPoint.java
@@ -1,0 +1,30 @@
+package ksh.deliveryhub.point.model;
+
+import ksh.deliveryhub.point.entity.UserPointEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserPoint {
+
+    private Long id;
+    private Integer balance;
+    private Long userId;
+
+    public static UserPoint from(UserPointEntity userPointEntity) {
+        return UserPoint.builder()
+            .id(userPointEntity.getId())
+            .balance(userPointEntity.getBalance())
+            .userId(userPointEntity.getUserId())
+            .build();
+    }
+
+    public UserPointEntity toEntity() {
+        return UserPointEntity.builder()
+            .id(getId())
+            .balance(getBalance())
+            .userId(getUserId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointRepository.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointRepository.java
@@ -1,0 +1,11 @@
+package ksh.deliveryhub.point.repository;
+
+import ksh.deliveryhub.point.entity.UserPointEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPointRepository extends JpaRepository<UserPointEntity, Long> {
+
+    Optional<UserPointEntity> findByUserId(long userId);
+}

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
@@ -1,0 +1,6 @@
+package ksh.deliveryhub.point.service;
+
+public interface UserPointService {
+
+    void checkBalance(long userId, int pointToUse);
+}

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
@@ -2,5 +2,5 @@ package ksh.deliveryhub.point.service;
 
 public interface UserPointService {
 
-    void checkBalance(long userId, int pointToUse);
+    void checkBalanceBeforeOrder(long userId, int pointToUse);
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
@@ -14,7 +14,7 @@ public class UserPointServiceImpl implements UserPointService{
     private final UserPointRepository userPointRepository;
 
     @Override
-    public void checkBalance(long userId, int pointToUse) {
+    public void checkBalanceBeforeOrder(long userId, int pointToUse) {
         UserPointEntity userPointEntity = userPointRepository.findByUserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_POINT_NOT_FOUND));
 

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
@@ -1,0 +1,25 @@
+package ksh.deliveryhub.point.service;
+
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.point.entity.UserPointEntity;
+import ksh.deliveryhub.point.repository.UserPointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPointServiceImpl implements UserPointService{
+
+    private final UserPointRepository userPointRepository;
+
+    @Override
+    public void checkBalance(long userId, int pointToUse) {
+        UserPointEntity userPointEntity = userPointRepository.findByUserId(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_POINT_NOT_FOUND));
+
+        if(userPointEntity.getBalance() < pointToUse) {
+            throw new CustomException(ErrorCode.USER_POINT_NOT_ENOUGH);
+        }
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -12,3 +12,4 @@ user.coupon.already.registered=이미 등록한 쿠폰입니다.
 user.coupon.not.usable=존재하지 않는 유저 쿠폰입니다.
 user.point.not.found=존재하지 않는 유저 포인트입니다.
 user.point.not.enough=사용 가능한 포인트 양이 부족합니다.
+cart.empty=카트가 비어있습니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -9,3 +9,4 @@ cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
 cart.menu.store.conflict=장바구니에 같은 가게의 메뉴만 담을 수 있습니다.
 coupon.not.found={0}는 존재하지 않는 쿠폰입니다.
 user.coupon.already.registered=이미 등록한 쿠폰입니다.
+user.coupon.not.usable=존재하지 않는 유저 쿠폰입니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -10,3 +10,5 @@ cart.menu.store.conflict=장바구니에 같은 가게의 메뉴만 담을 수 �
 coupon.not.found={0}는 존재하지 않는 쿠폰입니다.
 user.coupon.already.registered=이미 등록한 쿠폰입니다.
 user.coupon.not.usable=존재하지 않는 유저 쿠폰입니다.
+user.point.not.found=존재하지 않는 유저 포인트입니다.
+user.point.not.enough=사용 가능한 포인트 양이 부족합니다.

--- a/src/test/java/ksh/deliveryhub/cart/api/CartControllerTest.java
+++ b/src/test/java/ksh/deliveryhub/cart/api/CartControllerTest.java
@@ -13,6 +13,9 @@ import ksh.deliveryhub.menu.entity.MenuEntity;
 import ksh.deliveryhub.menu.entity.MenuOptionEntity;
 import ksh.deliveryhub.menu.repository.MenuOptionRepository;
 import ksh.deliveryhub.menu.repository.MenuRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import ksh.deliveryhub.store.entity.StoreEntity;
+import ksh.deliveryhub.store.repository.StoreRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -51,24 +54,32 @@ class CartControllerTest {
     @Autowired
     MenuOptionRepository menuOptionRepository;
 
+    @Autowired
+    StoreRepository storeRepository;
+
     @AfterEach
     void tearDown() {
         cartMenuRepository.deleteAllInBatch();
         cartRepository.deleteAllInBatch();
         menuRepository.deleteAllInBatch();
         menuOptionRepository.deleteAllInBatch();
+        storeRepository.deleteAllInBatch();
     }
 
     @Test
     public void 장바구니에_담긴_메뉴_정보를_조회에_성공하면_201응답을_받는다() throws Exception {
         //given
+        //가게 생성
+        StoreEntity storeEntity = StoreEntity.builder().build();
+        storeRepository.save(storeEntity);
+
         //카트 생성
         CartEntity cartEntity = createCartEntity(1L);
         cartRepository.save(cartEntity);
 
         //메뉴 생성
-        MenuEntity menuEntity1 = createMenuEntity("치즈 피자", "치즈 들어감", 10000, 1L);
-        MenuEntity menuEntity2 = createMenuEntity("페퍼로니 피자", "페퍼로니 들어감", 15000, 1L);
+        MenuEntity menuEntity1 = createMenuEntity("치즈 피자", "치즈 들어감", 10000, storeEntity.getId());
+        MenuEntity menuEntity2 = createMenuEntity("페퍼로니 피자", "페퍼로니 들어감", 15000, storeEntity.getId());
         menuRepository.saveAll(List.of(menuEntity1, menuEntity2));
 
         //메뉴의 옵션 생성

--- a/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
@@ -47,6 +47,7 @@ class CartMenuServiceImplTest {
         cartMenuRepository.deleteAllInBatch();
         menuRepository.deleteAllInBatch();
         menuOptionRepository.deleteAllInBatch();
+        storeRepository.deleteAllInBatch();
     }
 
     @Test

--- a/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/cart/service/CartMenuServiceImplTest.java
@@ -11,6 +11,8 @@ import ksh.deliveryhub.menu.entity.MenuOptionEntity;
 import ksh.deliveryhub.menu.entity.MenuStatus;
 import ksh.deliveryhub.menu.repository.MenuOptionRepository;
 import ksh.deliveryhub.menu.repository.MenuRepository;
+import ksh.deliveryhub.store.entity.StoreEntity;
+import ksh.deliveryhub.store.repository.StoreRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +38,9 @@ class CartMenuServiceImplTest {
 
     @Autowired
     private MenuOptionRepository menuOptionRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
 
     @AfterEach
     void tearDown() {
@@ -170,8 +175,11 @@ class CartMenuServiceImplTest {
     @Test
     public void 장바구니에_담긴_메뉴를_메뉴_옵션_정보와_함께_조회한다() {
         // given
-        MenuEntity menuEntity1 = createMenuEntity("일반 피자", 10000, 1L);
-        MenuEntity menuEntity2 = createMenuEntity("고급 피자", 15000, 1L);
+        StoreEntity storeEntity = StoreEntity.builder().build();
+        storeRepository.save(storeEntity);
+
+        MenuEntity menuEntity1 = createMenuEntity("일반 피자", 10000, storeEntity.getId());
+        MenuEntity menuEntity2 = createMenuEntity("고급 피자", 15000, storeEntity.getId());
         menuRepository.saveAll(List.of(menuEntity1, menuEntity2));
 
         MenuOptionEntity optionEntity = createMenuOptionEntity("치즈 추가", 500, menuEntity1.getId());

--- a/src/test/java/ksh/deliveryhub/coupon/service/UserCouponServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/service/UserCouponServiceImplTest.java
@@ -4,6 +4,7 @@ import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.coupon.entity.CouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
@@ -23,6 +24,7 @@ import java.time.ZoneId;
 import java.util.List;
 
 import static ksh.deliveryhub.coupon.entity.UserCouponStatus.ACTIVE;
+import static ksh.deliveryhub.coupon.entity.UserCouponStatus.RESERVED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -133,5 +135,74 @@ class UserCouponServiceImplTest {
                 tuple(1L, couponEntity1.getId()),
                 tuple(1L, couponEntity2.getId())
             );
+    }
+
+    @Test
+    public void 주문에_적용할_쿠폰을_예약_상태로_바꾼다() throws Exception{
+        //given
+        CouponEntity couponEntity = CouponEntity.builder()
+            .foodCategory(FoodCategory.PIZZA)
+            .discountAmount(1000)
+            .build();
+        couponRepository.save(couponEntity);
+
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .userId(1L)
+            .couponId(couponEntity.getId())
+            .couponStatus(ACTIVE)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        //when
+        UserCouponDetail userCouponDetail = userCouponService.reserveCoupon(userCouponEntity.getId(), 1L, couponEntity.getFoodCategory());
+
+        //then
+        UserCouponEntity reservedUserCouponEntity = userCouponRepository.findById(userCouponEntity.getId()).get();
+        assertThat(reservedUserCouponEntity.getCouponStatus()).isEqualTo(UserCouponStatus.RESERVED);
+        assertThat(userCouponDetail.getDiscountAmount()).isEqualTo(1000);
+    }
+
+    @Test
+    public void 쿠폰을_적용할_수_없는_음식_카테고리일_경우_쿠폰_사용_예약에_실패한다() throws Exception{
+        //given
+        CouponEntity couponEntity = CouponEntity.builder()
+            .foodCategory(FoodCategory.PIZZA)
+            .discountAmount(1000)
+            .build();
+        couponRepository.save(couponEntity);
+
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .userId(1L)
+            .couponId(couponEntity.getId())
+            .couponStatus(ACTIVE)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        //when //then
+        assertThatExceptionOfType(CustomException.class)
+            .isThrownBy(() -> userCouponService.reserveCoupon(userCouponEntity.getId(), 1L, FoodCategory.CHICKEN))
+            .returns(ErrorCode.USER_COUPON_NOT_USABLE, CustomException::getErrorCode);
+    }
+
+    @Test
+    public void 사용_가능한_상태의_쿠폰이_아닌_경우_쿠폰_사용_예약에_실패한다() throws Exception{
+        //given
+        CouponEntity couponEntity = CouponEntity.builder()
+            .foodCategory(FoodCategory.PIZZA)
+            .discountAmount(1000)
+            .build();
+        couponRepository.save(couponEntity);
+
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .userId(1L)
+            .couponId(couponEntity.getId())
+            .couponStatus(RESERVED)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        //when //then
+        assertThatExceptionOfType(CustomException.class)
+            .isThrownBy(() -> userCouponService.reserveCoupon(userCouponEntity.getId(), 1L, FoodCategory.CHICKEN))
+            .returns(ErrorCode.USER_COUPON_NOT_USABLE, CustomException::getErrorCode);
     }
 }

--- a/src/test/java/ksh/deliveryhub/order/api/OrderControllerTest.java
+++ b/src/test/java/ksh/deliveryhub/order/api/OrderControllerTest.java
@@ -1,0 +1,231 @@
+package ksh.deliveryhub.order.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ksh.deliveryhub.cart.entity.CartMenuEntity;
+import ksh.deliveryhub.cart.repository.CartMenuRepository;
+import ksh.deliveryhub.common.dto.response.SuccessResponseDto;
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import ksh.deliveryhub.menu.entity.MenuEntity;
+import ksh.deliveryhub.menu.entity.MenuOptionEntity;
+import ksh.deliveryhub.menu.entity.MenuStatus;
+import ksh.deliveryhub.menu.repository.MenuOptionRepository;
+import ksh.deliveryhub.menu.repository.MenuRepository;
+import ksh.deliveryhub.order.dto.request.OrderCreateRequestDto;
+import ksh.deliveryhub.order.dto.response.OrderCreateResponseDto;
+import ksh.deliveryhub.point.entity.UserPointEntity;
+import ksh.deliveryhub.point.repository.UserPointRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import ksh.deliveryhub.store.entity.StoreEntity;
+import ksh.deliveryhub.store.repository.StoreRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrderControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    CartMenuRepository cartMenuRepository;
+    @Autowired
+    UserCouponRepository userCouponRepository;
+    @Autowired
+    UserPointRepository userPointRepository;
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    MenuRepository menuRepository;
+    @Autowired
+    MenuOptionRepository menuOptionRepository;
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Test
+    void 사용할_쿠폰과_포인트_정보를_포함해_주문을_생성하고_주문_정보와_201_응답을_반환한다() throws Exception {
+        // given
+        StoreEntity store = createStore();
+        storeRepository.save(store);
+
+        MenuEntity menu1 = createMenu("치즈 피자", 10000, store.getId());
+        MenuEntity menu2 = createMenu("페퍼로니 피자", 15000, store.getId());
+        menuRepository.saveAll(List.of(menu1, menu2));
+
+        MenuOptionEntity option = createOption("치즈 추가", 500, menu1.getId());
+        menuOptionRepository.save(option);
+
+        CartMenuEntity cart1 = createCartMenu(1L, menu1.getId(), option.getId(), 2);
+        CartMenuEntity cart2 = createCartMenu(1L, menu2.getId(), null, 1);
+        cartMenuRepository.saveAll(List.of(cart1, cart2));
+
+        CouponEntity coupon = createCoupon(FoodCategory.PIZZA, 3000);
+        couponRepository.save(coupon);
+
+        UserCouponEntity userCoupon = createUserCoupon(1L, coupon.getId(), UserCouponStatus.ACTIVE);
+        userCouponRepository.save(userCoupon);
+
+        UserPointEntity userPoint = createUserPoint(1L, 10000);
+        userPointRepository.save(userPoint);
+
+        OrderCreateRequestDto request = createOrderCreateRequestDto(userCoupon.getId(), 2000);
+
+        //when
+        String json = mockMvc.perform(
+                post("/users/{userId}/orders", 1L)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        //then
+        var response = readResponseDto(json, OrderCreateResponseDto.class);
+        OrderCreateResponseDto responseDto = response.getData();
+        assertThat(responseDto.getId()).isNotZero();
+        assertThat(responseDto.getTotalPrice()).isEqualTo(31000);
+    }
+
+    @Test
+    void 쿠폰과_포인트를_사용하지_않아도_주문을_생성하고_201_응답을_받을_수_있다() throws Exception {
+        // given
+        StoreEntity store = createStore();
+        storeRepository.save(store);
+
+        MenuEntity menu1 = createMenu("치즈 피자", 10000, store.getId());
+        MenuEntity menu2 = createMenu("페퍼로니 피자", 15000, store.getId());
+        menuRepository.saveAll(List.of(menu1, menu2));
+
+        MenuOptionEntity option = createOption("치즈 추가", 500, menu1.getId());
+        menuOptionRepository.save(option);
+
+        CartMenuEntity cart1 = createCartMenu(1L, menu1.getId(), option.getId(), 2);
+        CartMenuEntity cart2 = createCartMenu(1L, menu2.getId(), null, 1);
+        cartMenuRepository.saveAll(List.of(cart1, cart2));
+
+        CouponEntity coupon = createCoupon(FoodCategory.PIZZA, 3000);
+        couponRepository.save(coupon);
+
+        UserCouponEntity userCoupon = createUserCoupon(1L, coupon.getId(), UserCouponStatus.ACTIVE);
+        userCouponRepository.save(userCoupon);
+
+        UserPointEntity userPoint = createUserPoint(1L, 10000);
+        userPointRepository.save(userPoint);
+
+        OrderCreateRequestDto request = createOrderCreateRequestDto(null, null);
+
+        //when
+        String json = mockMvc.perform(
+                post("/users/{userId}/orders", 1L)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        //then
+        var response = readResponseDto(json, OrderCreateResponseDto.class);
+        OrderCreateResponseDto responseDto = response.getData();
+        assertThat(responseDto.getId()).isNotZero();
+        assertThat(responseDto.getTotalPrice()).isEqualTo(36000);
+    }
+
+    private static StoreEntity createStore() {
+        return StoreEntity.builder()
+            .foodCategory(FoodCategory.PIZZA)
+            .build();
+    }
+
+    private static MenuEntity createMenu(String name, int price, long storeId) {
+        return MenuEntity.builder()
+            .name(name)
+            .description("설명")
+            .menuStatus(MenuStatus.AVAILABLE)
+            .price(price)
+            .image("https://example.com/image.png")
+            .storeId(storeId)
+            .build();
+    }
+
+    private static MenuOptionEntity createOption(String name, int price, long menuId) {
+        return MenuOptionEntity.builder()
+            .name(name)
+            .price(price)
+            .menuId(menuId)
+            .build();
+    }
+
+    private static CartMenuEntity createCartMenu(long cartId, long menuId, Long optionId, int qty) {
+        return CartMenuEntity.builder()
+            .cartId(cartId)
+            .menuId(menuId)
+            .optionId(optionId)
+            .quantity(qty)
+            .build();
+    }
+
+    private static CouponEntity createCoupon(FoodCategory category, int discount) {
+        return CouponEntity.builder()
+            .foodCategory(category)
+            .discountAmount(discount)
+            .build();
+    }
+
+    private static UserCouponEntity createUserCoupon(long userId, long couponId, UserCouponStatus status) {
+        return UserCouponEntity.builder()
+            .userId(userId)
+            .couponId(couponId)
+            .couponStatus(status)
+            .build();
+    }
+
+    private static UserPointEntity createUserPoint(long userId, int balance) {
+        return UserPointEntity.builder()
+            .userId(userId)
+            .balance(balance)
+            .build();
+    }
+
+    private static OrderCreateRequestDto createOrderCreateRequestDto(Long userCouponId, Integer pointToUse) {
+        return OrderCreateRequestDto.builder()
+            .userCouponId(userCouponId)
+            .pointToUse(pointToUse)
+            .build();
+    }
+
+    private <T> SuccessResponseDto<T> readResponseDto(
+        String json,
+        Class<T> responseDtoClass
+    ) throws JsonProcessingException {
+        JavaType dtoType = objectMapper.getTypeFactory()
+            .constructParametricType(SuccessResponseDto.class, responseDtoClass);
+
+        return objectMapper.readValue(json, dtoType);
+    }
+}


### PR DESCRIPTION
# 📝 주요 구현 사항

## 🛠️ 주문 생성 전 상태 검증

### ✅ 장바구니 메뉴 상태 확인
- 사용자가 장바구니에 메뉴를 담은 이후  
  주문 요청 전까지 해당 메뉴가 **주문 불가 상태**로 변경되었을 수 있습니다.  
- 따라서 주문 생성 전에 장바구니에 담긴 메뉴들을 순회하며  
  **현재 주문 가능한 상태인지 확인**합니다.

### ✅ 쿠폰 사용 가능 여부 검증
- 사용자가 입력한 쿠폰이  
  **만료되었거나 이미 사용된 쿠폰인지** 확인합니다.

### ✅ 사용자 포인트 잔액 검증
- 사용자가 포인트를 발급받은 적이 없거나  
  **포인트 잔액이 부족한지 여부를 검증**합니다.

## 🛠️ 주문 도메인 관련 엔티티 변경 사항

### 🧾 `OrderEntity` 변경 사항
- 다음 필드를 새로 추가하였습니다:
  - `discountAmount`: 쿠폰으로 인한 할인 금액
  - `usedPoint`: 사용한 포인트 금액
  - `finalPrice`: 최종 결제 금액 (할인 적용 후)
- 이 값들은 쿠폰 및 포인트 로그를 통해 계산할 수 있지만  
  **주문 생성 시점에 저장해두어**  
  효율적으로 조회하도록 변경했습니다.

### 🧾 `OrderItemEntity` 변경 사항
- 다음 필드를 새로 추가하였습니다:
  - `menuPrice`: 주문 시점의 메뉴 가격
  - `optionPrice`: 주문 시점의 옵션 가격
- 메뉴나 옵션 가격은 시간이 지나면 변경될 수 있으므로  
  **주문 당시 정보를 정확히 재현하기 위해** 해당 필드를 저장합니다.


## 🛠️ 주문 생성

- 장바구니 정보, 사용자 쿠폰 및 포인트 사용 정보를 바탕으로  
  **주문과 주문 항목(OrderItem)을 생성**합니다.
- 주문 생성 이후, **최종 결제 금액과 주문 ID**를 응답값으로 반환합니다.  
  클라이언트는 이를 통해 어떤 주문에 대해  
  얼마를 결제해야 하는지 판단할 수 있습니다.
