### PR TITLE
[#15] 결제 대기 중 주문에 대한 결제 처리 기능 구현

### DIFF
--- a/src/main/java/ksh/deliveryhub/cart/entity/CartEntity.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartEntity.java
@@ -26,6 +26,10 @@ public class CartEntity extends BaseEntity {
 
     private Long userId;
 
+    public void updateStatus(CartStatus status) {
+        this.status = status;
+    }
+
     @Builder
     private CartEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/cart/entity/CartStatus.java
+++ b/src/main/java/ksh/deliveryhub/cart/entity/CartStatus.java
@@ -2,5 +2,5 @@ package ksh.deliveryhub.cart.entity;
 
 public enum CartStatus {
     ACTIVE,
-    ORDERED
+    CLOSED
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartService.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartService.java
@@ -5,4 +5,6 @@ import ksh.deliveryhub.cart.model.Cart;
 public interface CartService {
 
     Cart getUserCart(long userId);
+
+    void closeCartAfterPayment(long userId);
 }

--- a/src/main/java/ksh/deliveryhub/cart/service/CartServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/cart/service/CartServiceImpl.java
@@ -4,6 +4,8 @@ import ksh.deliveryhub.cart.entity.CartEntity;
 import ksh.deliveryhub.cart.entity.CartStatus;
 import ksh.deliveryhub.cart.model.Cart;
 import ksh.deliveryhub.cart.repository.CartRepository;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +23,13 @@ public class CartServiceImpl implements CartService {
             .orElseGet(() -> cartRepository.save(createCartEntity(userId)));
 
         return Cart.from(userCartEntity);
+    }
+
+    @Override
+    public void closeCartAfterPayment(long userId) {
+        cartRepository.findByUserIdAndStatus(userId, CartStatus.ACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND))
+            .updateStatus(CartStatus.CLOSED);
     }
 
     private static CartEntity createCartEntity(long userId) {

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     USER_POINT_NOT_FOUND(404, "user.point.not.found"),
     USER_POINT_NOT_ENOUGH(400, "user.point.not.enough"),
     CART_EMPTY(400, "cart.empty"),
-    ORDER_NOT_FOUND(404, "order.not.found"),;
+    ORDER_NOT_FOUND(404, "order.not.found"),
+    CART_NOT_FOUND(404, "cart.not.found"),;
 
 
     private final int status;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     USER_COUPON_NOT_FOUND(404, "user.coupon.not.found"),
     USER_POINT_NOT_FOUND(404, "user.point.not.found"),
     USER_POINT_NOT_ENOUGH(400, "user.point.not.enough"),
-    CART_EMPTY(400, "cart.empty");
+    CART_EMPTY(400, "cart.empty"),
+    ORDER_NOT_FOUND(404, "order.not.found"),;
 
 
     private final int status;

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     COUPON_OUT_OF_STOCK(400, "coupon.out.of.stock"),
     USER_COUPON_ALREADY_REGISTERED(400, "user.coupon.already.registered"),
     USER_COUPON_NOT_USABLE(400, "user.coupon.not.usable"),
+    USER_COUPON_NOT_FOUND(404, "user.coupon.not.found"),
     USER_POINT_NOT_FOUND(404, "user.point.not.found"),
     USER_POINT_NOT_ENOUGH(400, "user.point.not.enough"),
     CART_EMPTY(400, "cart.empty");

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEventType.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEventType.java
@@ -1,7 +1,7 @@
 package ksh.deliveryhub.coupon.entity;
 
 public enum CouponEventType {
-    ISSUED,
+    ISSUE,
     USE,
-    CANCELLED
+    CANCEL
 }

--- a/src/main/java/ksh/deliveryhub/coupon/entity/CouponEventType.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/CouponEventType.java
@@ -2,6 +2,6 @@ package ksh.deliveryhub.coupon.entity;
 
 public enum CouponEventType {
     ISSUED,
-    APPLIED,
+    USE,
     CANCELLED
 }

--- a/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
+++ b/src/main/java/ksh/deliveryhub/coupon/entity/UserCouponEntity.java
@@ -32,6 +32,10 @@ public class UserCouponEntity extends BaseEntity {
         this.couponStatus = UserCouponStatus.RESERVED;
     }
 
+    public void use() {
+        this.couponStatus = UserCouponStatus.USED;
+    }
+
     @Builder
     private UserCouponEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepository.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.coupon.repository;
 
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.repository.projection.UserCouponDetailProjection;
 import ksh.deliveryhub.store.entity.FoodCategory;
 
@@ -11,4 +12,6 @@ public interface UserCouponQueryRepository {
     List<UserCouponDetailProjection> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
 
     Optional<UserCouponDetailProjection> findCouponToApply(long id, long userId, FoodCategory foodCategory);
+
+    UserCouponEntity getReservedCouponForPayment(long id, long userId);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponQueryRepositoryImpl.java
@@ -3,6 +3,9 @@ package ksh.deliveryhub.coupon.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.repository.projection.QUserCouponDetailProjection;
 import ksh.deliveryhub.coupon.repository.projection.UserCouponDetailProjection;
@@ -53,5 +56,23 @@ public class UserCouponQueryRepositoryImpl implements UserCouponQueryRepository 
             .fetchOne();
 
         return Optional.ofNullable(userCouponDetailProjection);
+    }
+
+    @Override
+    public UserCouponEntity getReservedCouponForPayment(long id, long userId) {
+        UserCouponEntity userCoupon = queryFactory
+            .selectFrom(userCouponEntity)
+            .where(
+                userCouponEntity.id.eq(id),
+                userCouponEntity.userId.eq(userId),
+                userCouponEntity.couponStatus.eq(UserCouponStatus.RESERVED)
+            )
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetchOne();
+
+        if (userCoupon == null) {
+            throw new CustomException(ErrorCode.USER_COUPON_NOT_FOUND);
+        }
+        return userCoupon;
     }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionService.java
@@ -6,4 +6,6 @@ import ksh.deliveryhub.coupon.model.UserCoupon;
 public interface CouponTransactionService {
 
     CouponTransaction saveIssueTransaction(UserCoupon userCoupon);
+
+    CouponTransaction saveUseTransaction(UserCoupon userCoupon, long orderId);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
@@ -18,7 +18,7 @@ public class CouponTransactionServiceImpl implements CouponTransactionService {
     public CouponTransaction saveIssueTransaction(UserCoupon userCoupon) {
         CouponTransactionEntity couponTransactionEntity = CouponTransactionEntity.builder()
             .userCouponId(userCoupon.getId())
-            .eventType(CouponEventType.ISSUED)
+            .eventType(CouponEventType.ISSUE)
             .build();
         couponTransactionRepository.save(couponTransactionEntity);
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/CouponTransactionServiceImpl.java
@@ -24,4 +24,16 @@ public class CouponTransactionServiceImpl implements CouponTransactionService {
 
         return CouponTransaction.from(couponTransactionEntity);
     }
+
+    @Override
+    public CouponTransaction saveUseTransaction(UserCoupon userCoupon, long orderId) {
+        CouponTransactionEntity couponTransactionEntity = CouponTransactionEntity.builder()
+            .userCouponId(userCoupon.getId())
+            .orderId(orderId)
+            .eventType(CouponEventType.USE)
+            .build();
+        couponTransactionRepository.save(couponTransactionEntity);
+
+        return CouponTransaction.from(couponTransactionEntity);
+    }
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -14,4 +14,6 @@ public interface UserCouponService {
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
 
     UserCouponDetail reserveCoupon(Long id, long userId, FoodCategory foodCategory);
+
+    UserCoupon useCoupon(long id, long userId);
 }

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -26,6 +26,7 @@ public class UserCouponServiceImpl implements UserCouponService {
     private final UserCouponRepository userCouponRepository;
     private final Clock clock;
 
+    @Transactional
     @Override
     public UserCoupon registerCoupon(long userId, Coupon coupon) {
         userCouponRepository.findByUserIdAndCouponId(userId, coupon.getId())
@@ -48,6 +49,7 @@ public class UserCouponServiceImpl implements UserCouponService {
         return UserCoupon.from(userCouponEntity);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory) {
         return userCouponRepository.findAvailableCouponsWithDetail(userId, foodCategory).stream()
@@ -76,6 +78,7 @@ public class UserCouponServiceImpl implements UserCouponService {
         return UserCouponDetail.fromEntities(userCouponEntity, couponEntity);
     }
 
+    @Transactional
     @Override
     public UserCoupon useCoupon(long id, long userId) {
         UserCouponEntity userCouponEntity = userCouponRepository.getReservedCouponForPayment(id, userId);

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -75,4 +75,12 @@ public class UserCouponServiceImpl implements UserCouponService {
 
         return UserCouponDetail.fromEntities(userCouponEntity, couponEntity);
     }
+
+    @Override
+    public UserCoupon useCoupon(long id, long userId) {
+        UserCouponEntity userCouponEntity = userCouponRepository.getReservedCouponForPayment(id, userId);
+        userCouponEntity.use();
+
+        return UserCoupon.from(userCouponEntity);
+    }
 }

--- a/src/main/java/ksh/deliveryhub/order/entity/OrderEntity.java
+++ b/src/main/java/ksh/deliveryhub/order/entity/OrderEntity.java
@@ -26,13 +26,17 @@ public class OrderEntity extends BaseEntity {
     private Integer finalPrice;
 
     @Enumerated(EnumType.STRING)
-    private OrderStatus status;
+    private OrderStatus orderStatus;
 
     private Long userId;
 
     private Long storeId;
 
     private Long riderId;
+
+    public void updateStatus(OrderStatus OrderStatus) {
+        this.orderStatus = OrderStatus;
+    }
 
     @Builder
     private OrderEntity(
@@ -41,7 +45,7 @@ public class OrderEntity extends BaseEntity {
         Integer discountAmount,
         Integer usedPoint,
         Integer finalPrice,
-        OrderStatus status,
+        OrderStatus orderStatus,
         Long userId,
         Long storeId,
         Long riderId
@@ -51,7 +55,7 @@ public class OrderEntity extends BaseEntity {
         this.discountAmount = discountAmount;
         this.usedPoint = usedPoint;
         this.finalPrice = finalPrice;
-        this.status = status;
+        this.orderStatus = orderStatus;
         this.userId = userId;
         this.storeId = storeId;
         this.riderId = riderId;

--- a/src/main/java/ksh/deliveryhub/order/entity/OrderEntity.java
+++ b/src/main/java/ksh/deliveryhub/order/entity/OrderEntity.java
@@ -26,7 +26,7 @@ public class OrderEntity extends BaseEntity {
     private Integer finalPrice;
 
     @Enumerated(EnumType.STRING)
-    private OrderStatus orderStatus;
+    private OrderStatus status;
 
     private Long userId;
 
@@ -41,7 +41,7 @@ public class OrderEntity extends BaseEntity {
         Integer discountAmount,
         Integer usedPoint,
         Integer finalPrice,
-        OrderStatus orderStatus,
+        OrderStatus status,
         Long userId,
         Long storeId,
         Long riderId
@@ -51,7 +51,7 @@ public class OrderEntity extends BaseEntity {
         this.discountAmount = discountAmount;
         this.usedPoint = usedPoint;
         this.finalPrice = finalPrice;
-        this.orderStatus = orderStatus;
+        this.status = status;
         this.userId = userId;
         this.storeId = storeId;
         this.riderId = riderId;

--- a/src/main/java/ksh/deliveryhub/order/entity/OrderStatus.java
+++ b/src/main/java/ksh/deliveryhub/order/entity/OrderStatus.java
@@ -2,6 +2,7 @@ package ksh.deliveryhub.order.entity;
 
 public enum OrderStatus {
     PENDING,
+    PAID,
     COOKING,
     DELIVERING,
     COMPLETED,

--- a/src/main/java/ksh/deliveryhub/order/model/Order.java
+++ b/src/main/java/ksh/deliveryhub/order/model/Order.java
@@ -14,7 +14,7 @@ public class Order {
     private Integer discountAmount;
     private Integer usedPoint;
     private Integer finalPrice;
-    private OrderStatus status;
+    private OrderStatus orderStatus;
     private Long userId;
     private Long storeId;
     private Long riderId;
@@ -26,7 +26,7 @@ public class Order {
             .discountAmount(orderEntity.getDiscountAmount())
             .usedPoint(orderEntity.getUsedPoint())
             .finalPrice(orderEntity.getFinalPrice())
-            .status(orderEntity.getStatus())
+            .orderStatus(orderEntity.getOrderStatus())
             .userId(orderEntity.getUserId())
             .storeId(orderEntity.getStoreId())
             .riderId(orderEntity.getRiderId())
@@ -40,7 +40,7 @@ public class Order {
             .discountAmount(getDiscountAmount())
             .usedPoint(getUsedPoint())
             .finalPrice(getFinalPrice())
-            .status(getStatus())
+            .orderStatus(getOrderStatus())
             .userId(getUserId())
             .storeId(getStoreId())
             .riderId(getRiderId())

--- a/src/main/java/ksh/deliveryhub/order/model/Order.java
+++ b/src/main/java/ksh/deliveryhub/order/model/Order.java
@@ -14,7 +14,7 @@ public class Order {
     private Integer discountAmount;
     private Integer usedPoint;
     private Integer finalPrice;
-    private OrderStatus orderStatus;
+    private OrderStatus status;
     private Long userId;
     private Long storeId;
     private Long riderId;
@@ -26,7 +26,7 @@ public class Order {
             .discountAmount(orderEntity.getDiscountAmount())
             .usedPoint(orderEntity.getUsedPoint())
             .finalPrice(orderEntity.getFinalPrice())
-            .orderStatus(orderEntity.getOrderStatus())
+            .status(orderEntity.getStatus())
             .userId(orderEntity.getUserId())
             .storeId(orderEntity.getStoreId())
             .riderId(orderEntity.getRiderId())
@@ -40,7 +40,7 @@ public class Order {
             .discountAmount(getDiscountAmount())
             .usedPoint(getUsedPoint())
             .finalPrice(getFinalPrice())
-            .orderStatus(getOrderStatus())
+            .status(getStatus())
             .userId(getUserId())
             .storeId(getStoreId())
             .riderId(getRiderId())

--- a/src/main/java/ksh/deliveryhub/order/repository/OrderRepository.java
+++ b/src/main/java/ksh/deliveryhub/order/repository/OrderRepository.java
@@ -1,7 +1,12 @@
 package ksh.deliveryhub.order.repository;
 
 import ksh.deliveryhub.order.entity.OrderEntity;
+import ksh.deliveryhub.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
+
+    Optional<OrderEntity> findByIdAndUserIdAndOrderStatus(long id, long userId, OrderStatus status);
 }

--- a/src/main/java/ksh/deliveryhub/order/service/OrderService.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderService.java
@@ -6,4 +6,6 @@ import ksh.deliveryhub.order.model.Order;
 public interface OrderService {
 
     Order createOrder(OrderCreateCommand command);
+
+    Order getPendingOrder(long id, long userId);
 }

--- a/src/main/java/ksh/deliveryhub/order/service/OrderService.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderService.java
@@ -8,4 +8,6 @@ public interface OrderService {
     Order createOrder(OrderCreateCommand command);
 
     Order getPendingOrder(long id, long userId);
+
+    void completePayment(long id);
 }

--- a/src/main/java/ksh/deliveryhub/order/service/OrderServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderServiceImpl.java
@@ -9,6 +9,7 @@ import ksh.deliveryhub.order.model.Order;
 import ksh.deliveryhub.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +45,14 @@ public class OrderServiceImpl implements OrderService{
             .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
         return Order.from(orderEntity);
+    }
+
+    @Transactional
+    @Override
+    public void completePayment(long id) {
+        OrderEntity orderEntity = orderRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        orderEntity.updateStatus(OrderStatus.PAID);
     }
 }

--- a/src/main/java/ksh/deliveryhub/order/service/OrderServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/order/service/OrderServiceImpl.java
@@ -1,6 +1,8 @@
 package ksh.deliveryhub.order.service;
 
 import ksh.deliveryhub.order.dto.command.OrderCreateCommand;
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.order.entity.OrderEntity;
 import ksh.deliveryhub.order.entity.OrderStatus;
 import ksh.deliveryhub.order.model.Order;
@@ -34,5 +36,13 @@ public class OrderServiceImpl implements OrderService{
         OrderEntity savedOrderEntity = orderRepository.save(orderEntity);
 
         return Order.from(savedOrderEntity);
+    }
+
+    @Override
+    public Order getPendingOrder(long id, long userId) {
+        OrderEntity orderEntity = orderRepository.findByIdAndUserIdAndOrderStatus(id, userId, OrderStatus.PENDING)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        return Order.from(orderEntity);
     }
 }

--- a/src/main/java/ksh/deliveryhub/payment/api/PaymentController.java
+++ b/src/main/java/ksh/deliveryhub/payment/api/PaymentController.java
@@ -1,0 +1,37 @@
+package ksh.deliveryhub.payment.api;
+
+import jakarta.validation.Valid;
+import ksh.deliveryhub.payment.dto.request.PaymentCreateRequestDto;
+import ksh.deliveryhub.payment.facade.PaymentFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentFacade paymentFacade;
+
+    @PostMapping("/orders/{orderId}/payments")
+    public ResponseEntity<Void> pay(
+        @PathVariable("orderId") long orderId,
+        @Valid @RequestBody PaymentCreateRequestDto request
+    ) {
+        paymentFacade.processPayment(
+            request.getUserId(),
+            orderId,
+            request.getUserCouponId(),
+            request.getPointToUse(),
+            request.getPaymentMethod()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/payment/dto/request/PaymentCreateRequestDto.java
+++ b/src/main/java/ksh/deliveryhub/payment/dto/request/PaymentCreateRequestDto.java
@@ -1,0 +1,25 @@
+package ksh.deliveryhub.payment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import ksh.deliveryhub.payment.entity.PaymentMethod;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentCreateRequestDto {
+
+    @NotNull(message = "유저 id는 필수입니다.")
+    private Long userId;
+
+    @NotNull(message = "사용할 쿠폰의 id는 필수입니다.")
+    private Long userCouponId;
+
+    @NotNull(message = "사용할 포인트 양은 필수입니다.")
+    @Positive(message = "사용할 포인트 양은 양수입니다.")
+    private Integer pointToUse;
+
+    @NotNull(message = "결제 방법은 필수입니다.")
+    private PaymentMethod paymentMethod;
+}

--- a/src/main/java/ksh/deliveryhub/payment/entity/PaymentEntity.java
+++ b/src/main/java/ksh/deliveryhub/payment/entity/PaymentEntity.java
@@ -20,9 +20,6 @@ public class PaymentEntity extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private PaymentMethod paymentMethod;
 
-    @Enumerated(value = EnumType.STRING)
-    private PaymentStatus paymentStatus;
-
     private Integer amount;
 
     private Long orderId;
@@ -31,13 +28,11 @@ public class PaymentEntity extends BaseEntity {
     private PaymentEntity(
         Long id,
         PaymentMethod paymentMethod,
-        PaymentStatus paymentStatus,
         Integer amount,
         Long orderId
     ) {
         this.id = id;
         this.paymentMethod = paymentMethod;
-        this.paymentStatus = paymentStatus;
         this.amount = amount;
         this.orderId = orderId;
     }

--- a/src/main/java/ksh/deliveryhub/payment/entity/PaymentStatus.java
+++ b/src/main/java/ksh/deliveryhub/payment/entity/PaymentStatus.java
@@ -1,6 +1,0 @@
-package ksh.deliveryhub.payment.entity;
-
-public enum PaymentStatus {
-    COMPLETED,
-    CANCELLED
-}

--- a/src/main/java/ksh/deliveryhub/payment/facade/PaymentFacade.java
+++ b/src/main/java/ksh/deliveryhub/payment/facade/PaymentFacade.java
@@ -13,6 +13,7 @@ import ksh.deliveryhub.point.service.UserPointService;
 import ksh.deliveryhub.point.service.UserPointTransactionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +27,7 @@ public class PaymentFacade {
     private final CartService cartService;
     private final PaymentService paymentService;
 
+    @Transactional
     public Payment processPayment(
         long userId,
         long orderId,

--- a/src/main/java/ksh/deliveryhub/payment/facade/PaymentFacade.java
+++ b/src/main/java/ksh/deliveryhub/payment/facade/PaymentFacade.java
@@ -1,0 +1,54 @@
+package ksh.deliveryhub.payment.facade;
+
+import ksh.deliveryhub.cart.service.CartService;
+import ksh.deliveryhub.coupon.model.UserCoupon;
+import ksh.deliveryhub.coupon.service.CouponTransactionService;
+import ksh.deliveryhub.coupon.service.UserCouponService;
+import ksh.deliveryhub.order.model.Order;
+import ksh.deliveryhub.order.service.OrderService;
+import ksh.deliveryhub.payment.entity.PaymentMethod;
+import ksh.deliveryhub.payment.model.Payment;
+import ksh.deliveryhub.payment.service.PaymentService;
+import ksh.deliveryhub.point.service.UserPointService;
+import ksh.deliveryhub.point.service.UserPointTransactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+    private final UserCouponService userCouponService;
+    private final CouponTransactionService couponTransactionService;
+    private final UserPointService userPointService;
+    private final UserPointTransactionService userPointTransactionService;
+    private final OrderService orderService;
+    private final CartService cartService;
+    private final PaymentService paymentService;
+
+    public Payment processPayment(
+        long userId,
+        long orderId,
+        Long userCouponId,
+        Integer pointToUse,
+        PaymentMethod paymentMethod
+    ) {
+        Order pendingOrder = orderService.getPendingOrder(orderId, userId);
+
+        UserCoupon userCoupon = userCouponService.useCoupon(userCouponId, userId);
+        couponTransactionService.saveUseTransaction(userCoupon, orderId);
+
+        if (pointToUse == null) {
+            int earnedPoint = userPointService.earnPoint(userId, pendingOrder.getFinalPrice());
+            userPointTransactionService.saveEarnTransaction(earnedPoint, orderId, userId);
+        } else {
+            userPointService.usePoint(userId, pointToUse);
+            userPointTransactionService.saveUseTransaction(pointToUse, orderId, userId);
+        }
+
+        orderService.completePayment(orderId);
+        cartService.closeCartAfterPayment(userId);
+
+        return paymentService.savePayment(paymentMethod, pendingOrder.getFinalPrice(), orderId);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/payment/model/Payment.java
+++ b/src/main/java/ksh/deliveryhub/payment/model/Payment.java
@@ -1,0 +1,33 @@
+package ksh.deliveryhub.payment.model;
+
+import ksh.deliveryhub.payment.entity.PaymentEntity;
+import ksh.deliveryhub.payment.entity.PaymentMethod;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Payment {
+    private Long id;
+    private PaymentMethod paymentMethod;
+    private Integer amount;
+    private Long orderId;
+
+    public static Payment from(PaymentEntity paymentEntity) {
+        return Payment.builder()
+            .id(paymentEntity.getId())
+            .paymentMethod(paymentEntity.getPaymentMethod())
+            .amount(paymentEntity.getAmount())
+            .orderId(paymentEntity.getOrderId())
+            .build();
+    }
+
+    public PaymentEntity toEntity() {
+        return PaymentEntity.builder()
+            .id(getId())
+            .paymentMethod(getPaymentMethod())
+            .amount(getAmount())
+            .orderId(getOrderId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/payment/repository/PaymentRepository.java
+++ b/src/main/java/ksh/deliveryhub/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.payment.repository;
+
+import ksh.deliveryhub.payment.entity.PaymentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+}

--- a/src/main/java/ksh/deliveryhub/payment/service/PaymentService.java
+++ b/src/main/java/ksh/deliveryhub/payment/service/PaymentService.java
@@ -1,0 +1,9 @@
+package ksh.deliveryhub.payment.service;
+
+import ksh.deliveryhub.payment.entity.PaymentMethod;
+import ksh.deliveryhub.payment.model.Payment;
+
+public interface PaymentService {
+
+    Payment savePayment(PaymentMethod paymentMethod, int amount, long orderId);
+}

--- a/src/main/java/ksh/deliveryhub/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,27 @@
+package ksh.deliveryhub.payment.service;
+
+import ksh.deliveryhub.payment.entity.PaymentEntity;
+import ksh.deliveryhub.payment.entity.PaymentMethod;
+import ksh.deliveryhub.payment.model.Payment;
+import ksh.deliveryhub.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService{
+
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    public Payment savePayment(PaymentMethod paymentMethod, int amount, long orderId) {
+        PaymentEntity paymentEntity = PaymentEntity.builder()
+            .paymentMethod(paymentMethod)
+            .amount(amount)
+            .orderId(orderId)
+            .build();
+        PaymentEntity savedPaymentEntity = paymentRepository.save(paymentEntity);
+
+        return Payment.from(savedPaymentEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/point/entity/UserPointEntity.java
+++ b/src/main/java/ksh/deliveryhub/point/entity/UserPointEntity.java
@@ -21,6 +21,10 @@ public class UserPointEntity extends BaseEntity {
 
     private Long userId;
 
+    public void decreaseBalance(Integer amount) {
+        this.balance -= amount;
+    }
+
     @Builder
     private UserPointEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/point/entity/UserPointEntity.java
+++ b/src/main/java/ksh/deliveryhub/point/entity/UserPointEntity.java
@@ -21,6 +21,10 @@ public class UserPointEntity extends BaseEntity {
 
     private Long userId;
 
+    public void increaseBalance(int amount) {
+        this.balance += amount;
+    }
+
     public void decreaseBalance(Integer amount) {
         this.balance -= amount;
     }

--- a/src/main/java/ksh/deliveryhub/point/entity/UserPointTransactionEntity.java
+++ b/src/main/java/ksh/deliveryhub/point/entity/UserPointTransactionEntity.java
@@ -30,7 +30,7 @@ public class UserPointTransactionEntity extends BaseEntity {
 
     private Long orderId;
 
-    private Long userPointId;
+    private Long userId;
 
     public void decreaseRemainingBalance(int amount) {
         this.remainingBalance -= amount;
@@ -44,7 +44,7 @@ public class UserPointTransactionEntity extends BaseEntity {
         Integer remainingBalance,
         LocalDate expireDate,
         Long orderId,
-        Long userPointId
+        Long userId
     ) {
         this.id = id;
         this.pointEventType = pointEventType;
@@ -52,6 +52,6 @@ public class UserPointTransactionEntity extends BaseEntity {
         this.remainingBalance = remainingBalance;
         this.expireDate = expireDate;
         this.orderId = orderId;
-        this.userPointId = userPointId;
+        this.userId = userId;
     }
 }

--- a/src/main/java/ksh/deliveryhub/point/entity/UserPointTransactionEntity.java
+++ b/src/main/java/ksh/deliveryhub/point/entity/UserPointTransactionEntity.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -26,7 +26,7 @@ public class UserPointTransactionEntity extends BaseEntity {
 
     private Integer remainingBalance;
 
-    private LocalDateTime expireDate;
+    private LocalDate expireDate;
 
     private Long orderId;
 
@@ -38,7 +38,7 @@ public class UserPointTransactionEntity extends BaseEntity {
         PointEventType pointEventType,
         Integer initialBalance,
         Integer remainingBalance,
-        LocalDateTime expireDate,
+        LocalDate expireDate,
         Long orderId,
         Long userPointId
     ) {

--- a/src/main/java/ksh/deliveryhub/point/entity/UserPointTransactionEntity.java
+++ b/src/main/java/ksh/deliveryhub/point/entity/UserPointTransactionEntity.java
@@ -32,6 +32,10 @@ public class UserPointTransactionEntity extends BaseEntity {
 
     private Long userPointId;
 
+    public void decreaseRemainingBalance(int amount) {
+        this.remainingBalance -= amount;
+    }
+
     @Builder
     private UserPointTransactionEntity(
         Long id,

--- a/src/main/java/ksh/deliveryhub/point/model/UserPointTransaction.java
+++ b/src/main/java/ksh/deliveryhub/point/model/UserPointTransaction.java
@@ -17,7 +17,7 @@ public class UserPointTransaction {
     private Integer remainingBalance;
     private LocalDate expireDate;
     private Long orderId;
-    private Long userPointId;
+    private Long userId;
 
     public static UserPointTransaction from(UserPointTransactionEntity entity) {
         return UserPointTransaction.builder()
@@ -27,7 +27,7 @@ public class UserPointTransaction {
             .remainingBalance(entity.getRemainingBalance())
             .expireDate(entity.getExpireDate())
             .orderId(entity.getOrderId())
-            .userPointId(entity.getUserPointId())
+            .userId(entity.getUserId())
             .build();
     }
 
@@ -39,7 +39,7 @@ public class UserPointTransaction {
             .remainingBalance(getRemainingBalance())
             .expireDate(getExpireDate())
             .orderId(getOrderId())
-            .userPointId(getUserPointId())
+            .userId(getUserId())
             .build();
     }
 }

--- a/src/main/java/ksh/deliveryhub/point/model/UserPointTransaction.java
+++ b/src/main/java/ksh/deliveryhub/point/model/UserPointTransaction.java
@@ -1,0 +1,45 @@
+package ksh.deliveryhub.point.model;
+
+import ksh.deliveryhub.point.entity.PointEventType;
+import ksh.deliveryhub.point.entity.UserPointTransactionEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserPointTransaction {
+
+    private Long id;
+    private PointEventType pointEventType;
+    private Integer initialBalance;
+    private Integer remainingBalance;
+    private LocalDate expireDate;
+    private Long orderId;
+    private Long userPointId;
+
+    public static UserPointTransaction from(UserPointTransactionEntity entity) {
+        return UserPointTransaction.builder()
+            .id(entity.getId())
+            .pointEventType(entity.getPointEventType())
+            .initialBalance(entity.getInitialBalance())
+            .remainingBalance(entity.getRemainingBalance())
+            .expireDate(entity.getExpireDate())
+            .orderId(entity.getOrderId())
+            .userPointId(entity.getUserPointId())
+            .build();
+    }
+
+    public UserPointTransactionEntity toEntity() {
+        return UserPointTransactionEntity.builder()
+            .id(getId())
+            .pointEventType(getPointEventType())
+            .initialBalance(getInitialBalance())
+            .remainingBalance(getRemainingBalance())
+            .expireDate(getExpireDate())
+            .orderId(getOrderId())
+            .userPointId(getUserPointId())
+            .build();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepository.java
@@ -1,0 +1,11 @@
+package ksh.deliveryhub.point.repository;
+
+import ksh.deliveryhub.point.entity.UserPointTransactionEntity;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface UserPointTransactionQueryRepository {
+
+    List<UserPointTransactionEntity> findAvailableEarningTransactions(long userPointId, LocalDate now);
+}

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepository.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface UserPointTransactionQueryRepository {
 
-    List<UserPointTransactionEntity> findAvailableEarningTransactions(long userPointId, LocalDate now);
+    List<UserPointTransactionEntity> findAvailableEarningTransactions(long userId, LocalDate now);
 }

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepositoryImpl.java
@@ -1,0 +1,33 @@
+package ksh.deliveryhub.point.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ksh.deliveryhub.point.entity.PointEventType;
+import ksh.deliveryhub.point.entity.UserPointTransactionEntity;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static ksh.deliveryhub.point.entity.QUserPointTransactionEntity.userPointTransactionEntity;
+
+@RequiredArgsConstructor
+public class UserPointTransactionQueryRepositoryImpl implements UserPointTransactionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserPointTransactionEntity> findAvailableEarningTransactions(long userPointId, LocalDate now) {
+        return queryFactory
+            .select(userPointTransactionEntity)
+            .from(userPointTransactionEntity)
+            .where(
+                userPointTransactionEntity.pointEventType.eq(PointEventType.EARN),
+                userPointTransactionEntity.userPointId.eq(userPointId),
+                userPointTransactionEntity.expireDate.after(LocalDate.now()),
+                userPointTransactionEntity.remainingBalance.gt(0)
+            )
+            .orderBy(userPointTransactionEntity.expireDate.asc())
+            .orderBy(userPointTransactionEntity.createdAt.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepositoryImpl.java
@@ -23,7 +23,7 @@ public class UserPointTransactionQueryRepositoryImpl implements UserPointTransac
             .where(
                 userPointTransactionEntity.pointEventType.eq(PointEventType.EARN),
                 userPointTransactionEntity.userId.eq(userId),
-                userPointTransactionEntity.expireDate.after(LocalDate.now()),
+                userPointTransactionEntity.expireDate.after(now),
                 userPointTransactionEntity.remainingBalance.gt(0)
             )
             .orderBy(userPointTransactionEntity.expireDate.asc())

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionQueryRepositoryImpl.java
@@ -16,13 +16,13 @@ public class UserPointTransactionQueryRepositoryImpl implements UserPointTransac
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<UserPointTransactionEntity> findAvailableEarningTransactions(long userPointId, LocalDate now) {
+    public List<UserPointTransactionEntity> findAvailableEarningTransactions(long userId, LocalDate now) {
         return queryFactory
             .select(userPointTransactionEntity)
             .from(userPointTransactionEntity)
             .where(
                 userPointTransactionEntity.pointEventType.eq(PointEventType.EARN),
-                userPointTransactionEntity.userPointId.eq(userPointId),
+                userPointTransactionEntity.userId.eq(userId),
                 userPointTransactionEntity.expireDate.after(LocalDate.now()),
                 userPointTransactionEntity.remainingBalance.gt(0)
             )

--- a/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionRepository.java
+++ b/src/main/java/ksh/deliveryhub/point/repository/UserPointTransactionRepository.java
@@ -1,0 +1,7 @@
+package ksh.deliveryhub.point.repository;
+
+import ksh.deliveryhub.point.entity.UserPointTransactionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPointTransactionRepository extends JpaRepository<UserPointTransactionEntity, Long>, UserPointTransactionQueryRepository {
+}

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
@@ -3,4 +3,6 @@ package ksh.deliveryhub.point.service;
 public interface UserPointService {
 
     void checkBalanceBeforeOrder(long userId, int pointToUse);
+
+    void usePoint(long userId, int pointToUse);
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
@@ -5,4 +5,6 @@ public interface UserPointService {
     void checkBalanceBeforeOrder(long userId, int pointToUse);
 
     void usePoint(long userId, int pointToUse);
+
+    void earnPoint(long userId, int finalPrice);
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointService.java
@@ -6,5 +6,5 @@ public interface UserPointService {
 
     void usePoint(long userId, int pointToUse);
 
-    void earnPoint(long userId, int finalPrice);
+    int earnPoint(long userId, int finalPrice);
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
@@ -35,4 +35,13 @@ public class UserPointServiceImpl implements UserPointService{
 
         userPointEntity.decreaseBalance(pointToUse);
     }
+
+    @Override
+    public void earnPoint(long userId, int finalPrice) {
+        UserPointEntity userPointEntity = userPointRepository.findByUserId(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_POINT_NOT_FOUND));
+
+        int earnedPoint = (int) (finalPrice * 0.1);
+        userPointEntity.increaseBalance(earnedPoint);
+    }
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
@@ -3,7 +3,6 @@ package ksh.deliveryhub.point.service;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.point.entity.UserPointEntity;
-import ksh.deliveryhub.point.model.UserPoint;
 import ksh.deliveryhub.point.repository.UserPointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,11 +36,13 @@ public class UserPointServiceImpl implements UserPointService{
     }
 
     @Override
-    public void earnPoint(long userId, int finalPrice) {
+    public int earnPoint(long userId, int finalPrice) {
         UserPointEntity userPointEntity = userPointRepository.findByUserId(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_POINT_NOT_FOUND));
 
         int earnedPoint = (int) (finalPrice * 0.1);
         userPointEntity.increaseBalance(earnedPoint);
+
+        return earnedPoint;
     }
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointServiceImpl.java
@@ -3,6 +3,7 @@ package ksh.deliveryhub.point.service;
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.point.entity.UserPointEntity;
+import ksh.deliveryhub.point.model.UserPoint;
 import ksh.deliveryhub.point.repository.UserPointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,5 +22,17 @@ public class UserPointServiceImpl implements UserPointService{
         if(userPointEntity.getBalance() < pointToUse) {
             throw new CustomException(ErrorCode.USER_POINT_NOT_ENOUGH);
         }
+    }
+
+    @Override
+    public void usePoint(long userId, int pointToUse) {
+        UserPointEntity userPointEntity = userPointRepository.findByUserId(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_POINT_NOT_FOUND));
+
+        if(userPointEntity.getBalance() < pointToUse) {
+            throw new CustomException(ErrorCode.USER_POINT_NOT_ENOUGH);
+        }
+
+        userPointEntity.decreaseBalance(pointToUse);
     }
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionService.java
@@ -5,4 +5,6 @@ import ksh.deliveryhub.point.model.UserPointTransaction;
 public interface UserPointTransactionService {
 
     UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userPointId);
+
+    void saveEarnTransaction(int earnedPoint, long orderId, long userPointId);
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionService.java
@@ -1,0 +1,8 @@
+package ksh.deliveryhub.point.service;
+
+import ksh.deliveryhub.point.model.UserPointTransaction;
+
+public interface UserPointTransactionService {
+
+    UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userPointId);
+}

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionService.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionService.java
@@ -4,7 +4,7 @@ import ksh.deliveryhub.point.model.UserPointTransaction;
 
 public interface UserPointTransactionService {
 
-    UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userPointId);
+    UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userId);
 
-    void saveEarnTransaction(int earnedPoint, long orderId, long userPointId);
+    void saveEarnTransaction(int earnedPoint, long orderId, long userId);
 }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
@@ -19,11 +19,11 @@ public class UserPointTransactionServiceImpl implements UserPointTransactionServ
     private final Clock clock;
 
     @Override
-    public UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userPointId) {
+    public UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userId) {
         LocalDate today = LocalDate.now(clock);
 
         List<UserPointTransactionEntity> earnings =
-            userPointTransactionRepository.findAvailableEarningTransactions(userPointId, today);
+            userPointTransactionRepository.findAvailableEarningTransactions(userId, today);
 
         deductPoints(earnings, amountToUse);
 
@@ -31,7 +31,7 @@ public class UserPointTransactionServiceImpl implements UserPointTransactionServ
             .pointEventType(PointEventType.USE)
             .initialBalance(amountToUse)
             .orderId(orderId)
-            .userPointId(userPointId)
+            .userId(userId)
             .build();
         userPointTransactionRepository.save(useTx);
 
@@ -39,7 +39,7 @@ public class UserPointTransactionServiceImpl implements UserPointTransactionServ
     }
 
     @Override
-    public void saveEarnTransaction(int earnedPoint, long orderId, long userPointId) {
+    public void saveEarnTransaction(int earnedPoint, long orderId, long userId) {
         LocalDate expireDate = LocalDate.now(clock).plusMonths(1);
 
         UserPointTransactionEntity earnedTransaction = UserPointTransactionEntity.builder()
@@ -48,7 +48,7 @@ public class UserPointTransactionServiceImpl implements UserPointTransactionServ
             .remainingBalance(earnedPoint)
             .expireDate(expireDate)
             .orderId(orderId)
-            .userPointId(userPointId)
+            .userId(userId)
             .build();
         userPointTransactionRepository.save(earnedTransaction);
     }

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
@@ -1,0 +1,51 @@
+package ksh.deliveryhub.point.service;
+
+import ksh.deliveryhub.point.entity.PointEventType;
+import ksh.deliveryhub.point.entity.UserPointTransactionEntity;
+import ksh.deliveryhub.point.model.UserPointTransaction;
+import ksh.deliveryhub.point.repository.UserPointTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserPointTransactionServiceImpl implements UserPointTransactionService{
+
+    private final UserPointTransactionRepository userPointTransactionRepository;
+    private final Clock clock;
+
+    @Override
+    public UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userPointId) {
+        LocalDate today = LocalDate.now(clock);
+
+        List<UserPointTransactionEntity> earnings =
+            userPointTransactionRepository.findAvailableEarningTransactions(userPointId, today);
+
+        deductPoints(earnings, amountToUse);
+
+        UserPointTransactionEntity useTx = UserPointTransactionEntity.builder()
+            .pointEventType(PointEventType.USE)
+            .initialBalance(amountToUse)
+            .orderId(orderId)
+            .userPointId(userPointId)
+            .build();
+        userPointTransactionRepository.save(useTx);
+
+        return UserPointTransaction.from(useTx);
+    }
+
+    private static void deductPoints(List<UserPointTransactionEntity> earnings, int amountToDeduct) {
+        int remaining = amountToDeduct;
+        for (UserPointTransactionEntity earn : earnings) {
+            if (remaining <= 0) break;
+
+            int deductionAmount = Math.min(earn.getRemainingBalance(), remaining);
+            earn.decreaseRemainingBalance(deductionAmount);
+            remaining -= deductionAmount;
+        }
+    }
+}

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
@@ -38,6 +38,21 @@ public class UserPointTransactionServiceImpl implements UserPointTransactionServ
         return UserPointTransaction.from(useTx);
     }
 
+    @Override
+    public void saveEarnTransaction(int earnedPoint, long orderId, long userPointId) {
+        LocalDate expireDate = LocalDate.now(clock).plusMonths(1);
+
+        UserPointTransactionEntity earnedTransaction = UserPointTransactionEntity.builder()
+            .pointEventType(PointEventType.EARN)
+            .initialBalance(earnedPoint)
+            .remainingBalance(earnedPoint)
+            .expireDate(expireDate)
+            .orderId(orderId)
+            .userPointId(userPointId)
+            .build();
+        userPointTransactionRepository.save(earnedTransaction);
+    }
+
     private static void deductPoints(List<UserPointTransactionEntity> earnings, int amountToDeduct) {
         int remaining = amountToDeduct;
         for (UserPointTransactionEntity earn : earnings) {

--- a/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImpl.java
@@ -6,6 +6,7 @@ import ksh.deliveryhub.point.model.UserPointTransaction;
 import ksh.deliveryhub.point.repository.UserPointTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ public class UserPointTransactionServiceImpl implements UserPointTransactionServ
     private final UserPointTransactionRepository userPointTransactionRepository;
     private final Clock clock;
 
+    @Transactional
     @Override
     public UserPointTransaction saveUseTransaction(int amountToUse, long orderId, long userId) {
         LocalDate today = LocalDate.now(clock);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -14,3 +14,4 @@ user.coupon.not.usable=존재하지 않는 유저 쿠폰입니다.
 user.point.not.found=존재하지 않는 유저 포인트입니다.
 user.point.not.enough=사용 가능한 포인트 양이 부족합니다.
 cart.empty=카트가 비어있습니다.
+order.not.found=존재하지 않는 주문입니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -9,6 +9,7 @@ cart.menu.not.found=상품이 장바구니에 존재하지 않습니다.
 cart.menu.store.conflict=장바구니에 같은 가게의 메뉴만 담을 수 있습니다.
 coupon.not.found={0}는 존재하지 않는 쿠폰입니다.
 user.coupon.already.registered=이미 등록한 쿠폰입니다.
+user.coupon.not.found=요청한 쿠폰이 존재하지 않습니다.
 user.coupon.not.usable=존재하지 않는 유저 쿠폰입니다.
 user.point.not.found=존재하지 않는 유저 포인트입니다.
 user.point.not.enough=사용 가능한 포인트 양이 부족합니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -15,3 +15,4 @@ user.point.not.found=존재하지 않는 유저 포인트입니다.
 user.point.not.enough=사용 가능한 포인트 양이 부족합니다.
 cart.empty=카트가 비어있습니다.
 order.not.found=존재하지 않는 주문입니다.
+cart.not.found=존재하지 않는 장바구니입니다.

--- a/src/test/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/point/service/UserPointTransactionServiceImplTest.java
@@ -1,0 +1,97 @@
+package ksh.deliveryhub.point.service;
+
+import ksh.deliveryhub.point.entity.PointEventType;
+import ksh.deliveryhub.point.entity.UserPointTransactionEntity;
+import ksh.deliveryhub.point.model.UserPointTransaction;
+import ksh.deliveryhub.point.repository.UserPointTransactionRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static ksh.deliveryhub.point.entity.PointEventType.EARN;
+import static ksh.deliveryhub.point.entity.PointEventType.USE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@SuppressWarnings("removal")
+class UserPointTransactionServiceImplTest {
+
+    @Autowired
+    UserPointTransactionService userPointTransactionService;
+
+    @Autowired
+    UserPointTransactionRepository userPointTransactionRepository;
+
+    @MockBean
+    Clock clock;
+
+    @AfterEach
+    void tearDown() {
+        userPointTransactionRepository.deleteAllInBatch();
+    }
+
+    @Test
+    public void 포인트_사용_시_만료_임박_순으로_차감하고_사용로그를_저장한다() throws Exception{
+        //given
+        //사용 가능한 포인트 기록 2개 저장
+        LocalDate expireDate1 = LocalDate.of(2021, 1, 2);
+        UserPointTransactionEntity availableUseTx1 = createUserPointTransactionEntity(EARN, 1000, 100, expireDate1, 1L);
+
+        LocalDate expireDate2 = LocalDate.of(2021, 1, 2);
+        UserPointTransactionEntity availableUseTx2 = createUserPointTransactionEntity(EARN, 1000, 1000, expireDate2, 1L);
+
+        //사용 불가능한 포인트 기록 저장
+        LocalDate expireDate3 = LocalDate.of(2020, 12, 31);
+        UserPointTransactionEntity expiredUseTx = createUserPointTransactionEntity(EARN, 2000, 2000, expireDate3, 1L);
+        userPointTransactionRepository.saveAll(List.of(availableUseTx1, availableUseTx2, expiredUseTx));
+
+        Instant fixedInstant = Instant.parse("2021-01-01T00:05:15Z");
+        ZoneId zone = ZoneId.of("Asia/Seoul");
+        given(clock.instant()).willReturn(fixedInstant);
+        given(clock.getZone()).willReturn(zone);
+
+        //when
+        UserPointTransaction userPointTransaction = userPointTransactionService.saveUseTransaction(700, 1L, 1L);
+
+        //then
+        UserPointTransactionEntity refreshedAvailableTx1 = userPointTransactionRepository
+            .findById(availableUseTx1.getId()).get();
+        assertThat(refreshedAvailableTx1.getRemainingBalance()).isZero();
+
+        UserPointTransactionEntity refreshedAvailableTx2 = userPointTransactionRepository
+            .findById(availableUseTx2.getId()).get();
+        assertThat(refreshedAvailableTx2.getRemainingBalance()).isEqualTo(400);
+
+        UserPointTransactionEntity refreshedExpiredTx = userPointTransactionRepository
+            .findById(expiredUseTx.getId()).get();
+        assertThat(refreshedExpiredTx.getRemainingBalance()).isEqualTo(2000);
+
+        assertThat(userPointTransaction).extracting("pointEventType", "initialBalance")
+            .containsExactly(USE, 700);
+    }
+
+    private UserPointTransactionEntity createUserPointTransactionEntity(
+        PointEventType type,
+        Integer initialBalance,
+        Integer remainingBalance,
+        LocalDate expireDate,
+        Long userId
+    ) {
+        return UserPointTransactionEntity.builder()
+            .pointEventType(type)
+            .initialBalance(initialBalance)
+            .remainingBalance(remainingBalance)
+            .expireDate(expireDate)
+            .userId(userId)
+            .build();
+    }
+}


### PR DESCRIPTION
# 💬 공유 사항

## 📌 결제 기능은 시뮬레이션용입니다

이번에 구현한 결제 처리 기능은 **라이더 관련 기능 개발을 위한 시뮬레이션 목적**입니다.  
실제 서비스에서는 **주문이 결제까지 완료된 상태여야** 라이더에게 푸시 알림을 보낼 수 있습니다.  
이에 따라 **결제가 완료된 것처럼 동작할 수 있도록 시뮬레이션용 주문-결제 처리 API**를 별도로 제공했습니다.

> 실제 서비스에서는 PG사를 통해 주문 생성과 동시에 결제를 처리하며,  
> 결제가 성공해야 주문이 확정되고 이후에 라이더 배정, 배송 푸시 등의 로직이 이어집니다.

---

# 📝 주요 구현 사항

## 🛠️ 결제 처리

결제 처리는 아래와 같은 흐름으로 수행됩니다:

1. 결제 대기 중(PENDING) 상태의 주문 조회  
2. 쿠폰 및 포인트 사용 처리  
3. 쿠폰 및 포인트 사용 로그 기록  
4. 주문 상태를 `결제 완료`로 변경  
5. 장바구니 비활성화 처리  
6. 결제 기록 저장  

---

## 🛠️ 포인트 사용 처리

- 포인트를 사용하지 않은 경우 → 결제 금액 기준으로 포인트를 적립하고, 적립 로그를 남깁니다.  
- 포인트를 사용한 경우 → 사용 가능한 적립 포인트를 사용 처리하고, 사용 로그를 남깁니다.

### ▶️ 포인트 사용 처리 로직

- 유저의 **만료되지 않고**, **잔여 포인트가 남아 있는 적립 로그**를 조회합니다.  
- **만료일이 빠른 순 → 적립 시점이 빠른 순**으로 정렬하여 순차적으로 차감합니다.  
- 요청된 사용량이 0이 될 때까지 차감하며 사용 로그를 남깁니다.

> 단순히 유저의 잔액만 관리할 수도 있지만,  
> 포인트 별 **만료일 관리와 이력 추적**을 위해 로그 기반으로 구현했습니다.

하지만 **매번 잔여 포인트를 로그 기반으로 계산하는 것은 비효율적**이므로,  
`UserPoint` 테이블에서 유저 단위의 포인트 총액을 캐싱하여 관리합니다.
