### PR TITLE
[#21] Redisson을 활용하여 쿠폰 발급 동시성 제어 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ java {
 ext {
     querydslVersion = '5.1.0'
     lombokVersion = '1.18.34'
+    redissonVersion = '3.46.0'
 }
 
 configurations {
@@ -42,8 +43,11 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
 
-    //데이터베이스
+    //H2
     runtimeOnly 'com.h2database:h2'
+
+    //Redis
+    implementation "org.redisson:redisson-spring-boot-starter:${redissonVersion}"
 
     //Jakarta API
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/deliveryhub/common/exception/ErrorCode.java
@@ -25,8 +25,10 @@ public enum ErrorCode {
     USER_POINT_NOT_ENOUGH(400, "user.point.not.enough"),
     CART_EMPTY(400, "cart.empty"),
     ORDER_NOT_FOUND(404, "order.not.found"),
-    CART_NOT_FOUND(404, "cart.not.found"),;
+    CART_NOT_FOUND(404, "cart.not.found"),
 
+    LOCK_ACQUIRE_INTERRUPTED(503, "lock.acquire.interrupted"),
+    LOCK_ACQUIRE_TIMEOUT(503, "lock.acquire.timeout");
 
     private final int status;
     private final String messageKey;

--- a/src/main/java/ksh/deliveryhub/common/lock/DistributedLockService.java
+++ b/src/main/java/ksh/deliveryhub/common/lock/DistributedLockService.java
@@ -1,0 +1,8 @@
+package ksh.deliveryhub.common.lock;
+
+import java.util.concurrent.TimeUnit;
+
+public interface DistributedLockService {
+
+    void acquire(String key, long waitTime, long leaseTime, TimeUnit timeUnit, Runnable businessLogic);
+}

--- a/src/main/java/ksh/deliveryhub/common/lock/RedissonDistributedLockService.java
+++ b/src/main/java/ksh/deliveryhub/common/lock/RedissonDistributedLockService.java
@@ -29,13 +29,7 @@ public class RedissonDistributedLockService implements DistributedLockService{
     ) {
         String lockKey = LOCK_PREFIX + key;
         RLock lock = redissonClient.getLock(lockKey);
-        boolean acquired;
-        try {
-            acquired = lock.tryLock(waitTime, leaseTime, unit);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new CustomException(ErrorCode.LOCK_ACQUIRE_INTERRUPTED);
-        }
+        boolean acquired = tryLock(waitTime, leaseTime, unit, lock);
 
         if (!acquired) {
             throw new CustomException(ErrorCode.LOCK_ACQUIRE_TIMEOUT);
@@ -44,17 +38,32 @@ public class RedissonDistributedLockService implements DistributedLockService{
         try {
             businessLogic.run();
         } finally {
-            if (TransactionSynchronizationManager.isActualTransactionActive()) {
-                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                    @Override
-                    public void afterCompletion(int status) {
-                        lock.unlock();
-                    }
-                });
-            } else {
-                lock.unlock();
-            }
+            unlock(lock);
         }
 
+    }
+
+    private static boolean tryLock(long waitTime, long leaseTime, TimeUnit unit, RLock lock) {
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(waitTime, leaseTime, unit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.LOCK_ACQUIRE_INTERRUPTED);
+        }
+        return acquired;
+    }
+
+    private static void unlock(RLock lock) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    lock.unlock();
+                }
+            });
+        } else {
+            lock.unlock();
+        }
     }
 }

--- a/src/main/java/ksh/deliveryhub/common/lock/RedissonDistributedLockService.java
+++ b/src/main/java/ksh/deliveryhub/common/lock/RedissonDistributedLockService.java
@@ -1,5 +1,7 @@
 package ksh.deliveryhub.common.lock;
 
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
@@ -32,11 +34,11 @@ public class RedissonDistributedLockService implements DistributedLockService{
             acquired = lock.tryLock(waitTime, leaseTime, unit);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IllegalStateException("락 획득 대기 중 인터럽트 발생", e);
+            throw new CustomException(ErrorCode.LOCK_ACQUIRE_INTERRUPTED);
         }
 
         if (!acquired) {
-            throw new IllegalStateException("락을 획득하지 못했습니다: " + lockKey);
+            throw new CustomException(ErrorCode.LOCK_ACQUIRE_TIMEOUT);
         }
 
         try {

--- a/src/main/java/ksh/deliveryhub/common/lock/RedissonDistributedLockService.java
+++ b/src/main/java/ksh/deliveryhub/common/lock/RedissonDistributedLockService.java
@@ -1,0 +1,58 @@
+package ksh.deliveryhub.common.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedissonDistributedLockService implements DistributedLockService{
+
+    private static final String LOCK_PREFIX = "lock:";
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public void acquire(
+        String key,
+        long waitTime,
+        long leaseTime,
+        TimeUnit unit,
+        Runnable businessLogic
+    ) {
+        String lockKey = LOCK_PREFIX + key;
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(waitTime, leaseTime, unit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("락 획득 대기 중 인터럽트 발생", e);
+        }
+
+        if (!acquired) {
+            throw new IllegalStateException("락을 획득하지 못했습니다: " + lockKey);
+        }
+
+        try {
+            businessLogic.run();
+        } finally {
+            if (TransactionSynchronizationManager.isActualTransactionActive()) {
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCompletion(int status) {
+                        lock.unlock();
+                    }
+                });
+            } else {
+                lock.unlock();
+            }
+        }
+
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.coupon.facade;
 
+import ksh.deliveryhub.common.lock.DistributedLockService;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +22,7 @@ public class CouponFacade {
     private final CouponService couponService;
     private final UserCouponService userCouponService;
     private final CouponTransactionService couponTransactionService;
+    private final DistributedLockService lockService;
 
     @Transactional
     public Coupon createCoupon(Coupon coupon) {
@@ -28,9 +31,17 @@ public class CouponFacade {
 
     @Transactional
     public void registerUserCoupon(long userId, String code) {
-        Coupon coupon = couponService.issueCoupon(code);
-        UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
-        couponTransactionService.saveIssueTransaction(userCoupon);
+        lockService.acquire(
+            code,
+            1000L,
+            50000L,
+            TimeUnit.MILLISECONDS,
+            () -> {
+                Coupon coupon = couponService.issueCoupon(code);
+                UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
+                couponTransactionService.saveIssueTransaction(userCoupon);
+            }
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ksh/deliveryhub/coupon/repository/CouponRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/CouponRepository.java
@@ -1,14 +1,11 @@
 package ksh.deliveryhub.coupon.repository;
 
-import jakarta.persistence.LockModeType;
 import ksh.deliveryhub.coupon.entity.CouponEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<CouponEntity, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<CouponEntity> findByCode(String code);
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -16,3 +16,6 @@ user.point.not.enough=사용 가능한 포인트 양이 부족합니다.
 cart.empty=카트가 비어있습니다.
 order.not.found=존재하지 않는 주문입니다.
 cart.not.found=존재하지 않는 장바구니입니다.
+
+lock.acquire.interrupted=락 대기 중 스레드가 인터럽트되었습니다.
+lock.acquire.timeout=락을 대기하는 중 타임아웃이 발생했습니다.

--- a/src/test/java/ksh/deliveryhub/coupon/facade/CouponFacadeTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/facade/CouponFacadeTest.java
@@ -1,0 +1,98 @@
+package ksh.deliveryhub.coupon.facade;
+
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.util.CouponCodeUtils;
+import ksh.deliveryhub.coupon.entity.CouponEntity;
+import ksh.deliveryhub.coupon.repository.CouponRepository;
+import ksh.deliveryhub.store.entity.FoodCategory;
+import org.jmock.lib.concurrent.Blitzer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static ksh.deliveryhub.coupon.entity.CouponStatus.ACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CouponFacadeTest {
+
+    @Autowired
+    CouponFacade couponFacade;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Test
+    public void 여러_유저가_동시에_요청했을_때_쿠폰이_모두_소진되면_더_이상_발행하지_않는다() throws Exception {
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 95, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        Blitzer blitzer = new Blitzer(100, 100);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        AtomicLong userIdSequence = new AtomicLong(1L);
+
+        //when
+        blitzer.blitz(
+            () -> {
+                long userId = userIdSequence.getAndIncrement();
+                try {
+                    couponFacade.registerUserCoupon(userId, code);
+                    successCount.incrementAndGet();
+                } catch (CustomException e) {
+                    System.out.println("예외 정보 " + e.getErrorCode().name());
+                    failureCount.incrementAndGet();
+                }
+            }
+        );
+
+        //then
+        System.out.println(userIdSequence.get());
+        assertThat(successCount.get()).isEqualTo(95);
+        assertThat(failureCount.get()).isEqualTo(5);
+    }
+
+    @Test
+    public void 한_유저가_쿠폰을_여러번_등록하려_시도하면_최초_1회만_통과한다() throws Exception {
+        //given
+        String code = CouponCodeUtils.generateCode();
+        CouponEntity couponEntity = createCouponEntity(code, 95, FoodCategory.PIZZA);
+        couponRepository.save(couponEntity);
+
+        Blitzer blitzer = new Blitzer(100, 100);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        //when
+        blitzer.blitz(
+            () -> {
+                try {
+                    couponFacade.registerUserCoupon(1, code);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                }
+            }
+        );
+
+        //then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failureCount.get()).isEqualTo(99);
+    }
+
+    private static CouponEntity createCouponEntity(String code, int remainingQuantity, FoodCategory foodCategory) {
+        return CouponEntity.builder()
+            .code(code)
+            .remainingQuantity(remainingQuantity)
+            .couponStatus(ACTIVE)
+            .duration(30)
+            .foodCategory(foodCategory)
+            .build();
+    }
+}

--- a/src/test/java/ksh/deliveryhub/coupon/service/CouponServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/service/CouponServiceImplTest.java
@@ -4,13 +4,10 @@ import ksh.deliveryhub.common.util.CouponCodeUtils;
 import ksh.deliveryhub.coupon.entity.CouponEntity;
 import ksh.deliveryhub.coupon.repository.CouponRepository;
 import ksh.deliveryhub.store.entity.FoodCategory;
-import org.jmock.lib.concurrent.Blitzer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static ksh.deliveryhub.coupon.entity.CouponStatus.ACTIVE;
 import static ksh.deliveryhub.coupon.entity.CouponStatus.INACTIVE;
@@ -58,34 +55,6 @@ class CouponServiceImplTest {
         //then
         CouponEntity decreasedCouponEntity = couponRepository.findById(couponEntity.getId()).get();
         assertThat(decreasedCouponEntity.getCouponStatus()).isEqualTo(INACTIVE);
-    }
-
-    @Test
-    public void 여러_유저가_동시에_요청했을_때_쿠폰_수가_부족하면_더_이상_발행하지_않는다() throws Exception{
-        //given
-        String code = CouponCodeUtils.generateCode();
-        CouponEntity couponEntity = createCouponEntity(code, 95, FoodCategory.PIZZA);
-        couponRepository.save(couponEntity);
-
-        Blitzer blitzer = new Blitzer(100, 1);
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger failureCount = new AtomicInteger(0);
-
-        //when
-        blitzer.blitz(
-            () -> {
-                try {
-                    couponService.issueCoupon(code);
-                    successCount.incrementAndGet();
-                } catch (Exception e) {
-                    failureCount.incrementAndGet();
-                }
-            }
-        );
-
-        //then
-        assertThat(successCount.get()).isEqualTo(95);
-        assertThat(failureCount.get()).isEqualTo(5);
     }
 
     private static CouponEntity createCouponEntity(String code, int remainingQuantity, FoodCategory foodCategory) {


### PR DESCRIPTION
# 📝 주요 구현 사항

## 🛠️ Redisson을 이용한 동시성 제어

### 비관적 락 제거의 필요성
- 선착순 쿠폰 발급은 짧은 시간 동안 동시 요청이 집중되는 구조로, DB에 부하가 가해질 가능성이 높습니다.  
- 기존에는 DB 비관적 락으로 동시성을 제어했으나, 트래픽이 몰릴 경우 락 대기 시간이 길어져 성능 저하가 발생할 수 있습니다.  
- 따라서 애플리케이션 단에서 분산락으로 선제적으로 요청을 제한하고, 락 획득 시에만 DB 쿼리를 수행함으로써, DB에는 실제 발급 가능한 수량만큼의 요청만 전달되어 부하를 최소화 하고자 합니다.

### Redisson 선택 이유
- MySQL named lock은 락 해제 관리가 어렵고 커넥션을 이중으로 소모하여 부하 및 커넥션 대기를 유발할 수 있습니다.
- Redis는 메모리 기반으로 처리 속도가 빠르며, 향후 어뷰징 방지나 캐싱 등에도 활용할 수 있어 확장성이 뛰어납니다.  
- Lettuce는 스핀 락 방식으로 Redis에 지속적으로 요청을 보내 부하를 유발할 수 있으나, Redisson은 pub/sub 기반으로 Redis 부하가 적고 안정적입니다.  
- 따라서 현재 단일 서버 환경이라 하더라도, 인프라 구성 비용을 감수하고 Redis와 Redisson을 도입하는 것이 전체 시스템의 성능과 확장성 측면에서 더 유리하다 판단했습니다.
