### PR TITLE
[#23] 쿠폰 발급 시 유저 쿠폰 저장 과정을 Kafka 기반 비동기적으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     //Redis
     implementation "org.redisson:redisson-spring-boot-starter:${redissonVersion}"
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     //Jakarta API
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     //Lombok
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
@@ -57,6 +58,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.jmock:jmock:2.12.0'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka:latest
+    container_name: kafka
+    ports:
+      - "9093:9093"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    depends_on:
+      - zookeeper
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  redis:
+    image: redis:7.2
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: [ "redis-server" ]
+    restart: unless-stopped
+
+volumes:
+  redis-data:

--- a/src/main/java/ksh/deliveryhub/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/ksh/deliveryhub/common/config/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package ksh.deliveryhub.common.config;
 
+import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
@@ -58,7 +59,7 @@ public class KafkaConsumerConfig {
             recoverer,
             new FixedBackOff(1000L, 2L)
         );
-
+        errorHandler.addNotRetryableExceptions(CustomException.class);
         factory.setCommonErrorHandler(errorHandler);
 
         return factory;

--- a/src/main/java/ksh/deliveryhub/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/ksh/deliveryhub/common/config/KafkaConsumerConfig.java
@@ -2,13 +2,18 @@ package ksh.deliveryhub.common.config;
 
 import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,9 +38,28 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, UserCouponRegisterEvent> kafkaListenerContainerFactory() {
+    public ConcurrentKafkaListenerContainerFactory<String, UserCouponRegisterEvent> kafkaListenerContainerFactory(
+        ConsumerFactory<String, UserCouponRegisterEvent> cf,
+        KafkaTemplate<String, UserCouponRegisterEvent> template
+    ) {
+
         ConcurrentKafkaListenerContainerFactory<String, UserCouponRegisterEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
+        factory.setConsumerFactory(cf);
+
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+            template,
+            (record, ex) -> {
+                record.headers().add("error-message", ex.getMessage().getBytes());
+                return new TopicPartition(record.topic() + ".DLT", record.partition());
+            }
+        );
+
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+            recoverer,
+            new FixedBackOff(1000L, 2L)
+        );
+
+        factory.setCommonErrorHandler(errorHandler);
 
         return factory;
     }

--- a/src/main/java/ksh/deliveryhub/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/ksh/deliveryhub/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,42 @@
+package ksh.deliveryhub.common.config;
+
+import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, UserCouponRegisterEvent> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9093");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "coupon-register-consumer");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "ksh.deliveryhub.coupon.dto.event");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent");
+        return new DefaultKafkaConsumerFactory<>(
+            props,
+            new StringDeserializer(),
+            new JsonDeserializer<>(UserCouponRegisterEvent.class)
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, UserCouponRegisterEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, UserCouponRegisterEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        return factory;
+    }
+}

--- a/src/main/java/ksh/deliveryhub/common/config/KafkaProducerConfig.java
+++ b/src/main/java/ksh/deliveryhub/common/config/KafkaProducerConfig.java
@@ -1,0 +1,32 @@
+package ksh.deliveryhub.common.config;
+
+import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, UserCouponRegisterEvent> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9093");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, UserCouponRegisterEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/ksh/deliveryhub/common/config/RedisConfig.java
+++ b/src/main/java/ksh/deliveryhub/common/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package ksh.deliveryhub.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer(StandardCharsets.UTF_8));
+        template.setValueSerializer(new StringRedisSerializer(StandardCharsets.UTF_8));
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/ksh/deliveryhub/common/redis/CacheKey.java
+++ b/src/main/java/ksh/deliveryhub/common/redis/CacheKey.java
@@ -1,0 +1,17 @@
+package ksh.deliveryhub.common.redis;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheKey {
+
+    REGISTERED_USER_SET("coupon:%s:registered:user:set");
+
+    private final String key;
+
+    public String makeKey(String... args) {
+        return String.format(key, args);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/consumer/DeadLetterTopicConsumer.java
+++ b/src/main/java/ksh/deliveryhub/coupon/consumer/DeadLetterTopicConsumer.java
@@ -1,0 +1,77 @@
+package ksh.deliveryhub.coupon.consumer;
+
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
+import ksh.deliveryhub.coupon.entity.CouponEventType;
+import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
+import ksh.deliveryhub.coupon.repository.CouponTransactionRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeadLetterTopicConsumer {
+
+    private final UserCouponRepository userCouponRepository;
+    private final CouponTransactionRepository couponTransactionRepository;
+    private final Clock clock;
+
+    @KafkaListener(
+        topics = "coupon-register.DLT",
+        groupId = "coupon-register-consumer",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    @Transactional
+    public void listen(ConsumerRecord<String, UserCouponRegisterEvent> record) {
+        Header header = record.headers().lastHeader("error-message");
+        String errorMessage = new String(header.value(), StandardCharsets.UTF_8);
+        log.error("쿠폰 발급 과정에서 예외 발생 {}", errorMessage);
+
+        UserCouponRegisterEvent event = record.value();
+        UserCouponEntity userCouponEntity = saveUserCouponEntity(event);
+        saveUserCouponTransactionLog(userCouponEntity);
+    }
+
+    private UserCouponEntity saveUserCouponEntity(UserCouponRegisterEvent event) {
+        userCouponRepository.findByUserIdAndCouponId(event.getUserId(), event.getCouponId())
+            .ifPresent(userCouponEntity ->
+                {throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);}
+            );
+
+
+        int duration = event.getDuration();
+        LocalDate expireAt = LocalDate.now(clock).plusDays(duration);
+
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .couponStatus(UserCouponStatus.ACTIVE)
+            .userId(event.getUserId())
+            .couponId(event.getCouponId())
+            .expireAt(expireAt)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        return userCouponEntity;
+    }
+
+    private void saveUserCouponTransactionLog(UserCouponEntity userCouponEntity) {
+        CouponTransactionEntity couponTransactionEntity = CouponTransactionEntity.builder()
+            .userCouponId(userCouponEntity.getId())
+            .eventType(CouponEventType.ISSUE)
+            .build();
+        couponTransactionRepository.save(couponTransactionEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/consumer/UserCouponRegisterConsumer.java
+++ b/src/main/java/ksh/deliveryhub/coupon/consumer/UserCouponRegisterConsumer.java
@@ -1,5 +1,7 @@
 package ksh.deliveryhub.coupon.consumer;
 
+import ksh.deliveryhub.common.exception.CustomException;
+import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
 import ksh.deliveryhub.coupon.entity.CouponEventType;
 import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
@@ -36,6 +38,12 @@ public class UserCouponRegisterConsumer {
     }
 
     private UserCouponEntity saveUserCouponEntity(UserCouponRegisterEvent event) {
+        userCouponRepository.findByUserIdAndCouponId(event.getUserId(), event.getCouponId())
+            .ifPresent(userCouponEntity ->
+                {throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);}
+            );
+
+
         int duration = event.getDuration();
         LocalDate expireAt = LocalDate.now(clock).plusDays(duration);
 

--- a/src/main/java/ksh/deliveryhub/coupon/consumer/UserCouponRegisterConsumer.java
+++ b/src/main/java/ksh/deliveryhub/coupon/consumer/UserCouponRegisterConsumer.java
@@ -1,0 +1,60 @@
+package ksh.deliveryhub.coupon.consumer;
+
+import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
+import ksh.deliveryhub.coupon.entity.CouponEventType;
+import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponEntity;
+import ksh.deliveryhub.coupon.entity.UserCouponStatus;
+import ksh.deliveryhub.coupon.repository.CouponTransactionRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class UserCouponRegisterConsumer {
+
+    private final UserCouponRepository userCouponRepository;
+    private final CouponTransactionRepository couponTransactionRepository;
+    private final Clock clock;
+
+
+    @KafkaListener(
+        topics = "coupon-register",
+        groupId = "coupon-register-consumer",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    @Transactional
+    public void listen(UserCouponRegisterEvent event) {
+        UserCouponEntity userCouponEntity = saveUserCouponEntity(event);
+        saveUserCouponTransactionLog(userCouponEntity);
+    }
+
+    private UserCouponEntity saveUserCouponEntity(UserCouponRegisterEvent event) {
+        int duration = event.getDuration();
+        LocalDate expireAt = LocalDate.now(clock).plusDays(duration);
+
+        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
+            .couponStatus(UserCouponStatus.ACTIVE)
+            .userId(event.getUserId())
+            .couponId(event.getCouponId())
+            .expireAt(expireAt)
+            .build();
+        userCouponRepository.save(userCouponEntity);
+
+        return userCouponEntity;
+    }
+
+    private void saveUserCouponTransactionLog(UserCouponEntity userCouponEntity) {
+        CouponTransactionEntity couponTransactionEntity = CouponTransactionEntity.builder()
+            .userCouponId(userCouponEntity.getId())
+            .eventType(CouponEventType.ISSUE)
+            .build();
+        couponTransactionRepository.save(couponTransactionEntity);
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/consumer/UserCouponRegisterConsumer.java
+++ b/src/main/java/ksh/deliveryhub/coupon/consumer/UserCouponRegisterConsumer.java
@@ -2,12 +2,14 @@ package ksh.deliveryhub.coupon.consumer;
 
 import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
+import ksh.deliveryhub.common.redis.CacheKey;
 import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
 import ksh.deliveryhub.coupon.entity.CouponEventType;
 import ksh.deliveryhub.coupon.entity.CouponTransactionEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.repository.CouponTransactionRepository;
+import ksh.deliveryhub.coupon.repository.UserCouponCacheRepository;
 import ksh.deliveryhub.coupon.repository.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -23,6 +25,7 @@ public class UserCouponRegisterConsumer {
 
     private final UserCouponRepository userCouponRepository;
     private final CouponTransactionRepository couponTransactionRepository;
+    private final UserCouponCacheRepository userCouponCacheRepository;
     private final Clock clock;
 
 
@@ -38,10 +41,11 @@ public class UserCouponRegisterConsumer {
     }
 
     private UserCouponEntity saveUserCouponEntity(UserCouponRegisterEvent event) {
-        userCouponRepository.findByUserIdAndCouponId(event.getUserId(), event.getCouponId())
-            .ifPresent(userCouponEntity ->
-                {throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);}
-            );
+        String key = CacheKey.REGISTERED_USER_SET.makeKey(String.valueOf(event.getUserId()));
+        boolean alreadyRegistered = userCouponCacheRepository.addRegisteredUserIdInSet(key, event.getUserId());
+        if(alreadyRegistered) {
+            throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);
+        }
 
 
         int duration = event.getDuration();

--- a/src/main/java/ksh/deliveryhub/coupon/dto/event/UserCouponRegisterEvent.java
+++ b/src/main/java/ksh/deliveryhub/coupon/dto/event/UserCouponRegisterEvent.java
@@ -1,0 +1,15 @@
+package ksh.deliveryhub.coupon.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserCouponRegisterEvent {
+
+    private long couponId;
+    private long userId;
+    private int duration;
+}

--- a/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
+++ b/src/main/java/ksh/deliveryhub/coupon/facade/CouponFacade.java
@@ -2,10 +2,8 @@ package ksh.deliveryhub.coupon.facade;
 
 import ksh.deliveryhub.common.lock.DistributedLockService;
 import ksh.deliveryhub.coupon.model.Coupon;
-import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
 import ksh.deliveryhub.coupon.service.CouponService;
-import ksh.deliveryhub.coupon.service.CouponTransactionService;
 import ksh.deliveryhub.coupon.service.UserCouponService;
 import ksh.deliveryhub.store.entity.FoodCategory;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +19,6 @@ public class CouponFacade {
 
     private final CouponService couponService;
     private final UserCouponService userCouponService;
-    private final CouponTransactionService couponTransactionService;
     private final DistributedLockService lockService;
 
     @Transactional
@@ -38,8 +35,7 @@ public class CouponFacade {
             TimeUnit.MILLISECONDS,
             () -> {
                 Coupon coupon = couponService.issueCoupon(code);
-                UserCoupon userCoupon = userCouponService.registerCoupon(userId, coupon);
-                couponTransactionService.saveIssueTransaction(userCoupon);
+                userCouponService.registerCoupon(userId, coupon);
             }
         );
     }

--- a/src/main/java/ksh/deliveryhub/coupon/producer/UserCouponRegisterProducer.java
+++ b/src/main/java/ksh/deliveryhub/coupon/producer/UserCouponRegisterProducer.java
@@ -1,0 +1,23 @@
+package ksh.deliveryhub.coupon.producer;
+
+import ksh.deliveryhub.coupon.dto.event.UserCouponRegisterEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserCouponRegisterProducer {
+
+    private final String TOPIC_NAME = "coupon-register";
+
+    private final KafkaTemplate<String, UserCouponRegisterEvent> kafkaTemplate;
+
+    public void register(long couponId, long userId, int duration) {
+        UserCouponRegisterEvent registerEvent = new UserCouponRegisterEvent(couponId, userId, duration);
+        kafkaTemplate.send(TOPIC_NAME, registerEvent);
+        log.info("메세지 발행 성공");
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponCacheRepository.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponCacheRepository.java
@@ -1,0 +1,6 @@
+package ksh.deliveryhub.coupon.repository;
+
+public interface UserCouponCacheRepository {
+
+    boolean addRegisteredUserIdInSet(String key, long userId);
+}

--- a/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponCacheRepositoryImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/repository/UserCouponCacheRepositoryImpl.java
@@ -1,0 +1,23 @@
+package ksh.deliveryhub.coupon.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCouponCacheRepositoryImpl implements UserCouponCacheRepository{
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public boolean addRegisteredUserIdInSet(String key, long userId) {
+        Long result = redisTemplate.opsForSet().add(key, userId);
+        if(result == 0)
+            redisTemplate.expire(key, 1, TimeUnit.HOURS);
+
+        return result == 1;
+    }
+}

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface UserCouponService {
 
-    UserCoupon registerCoupon(long userId, Coupon coupon);
+    void registerCoupon(long userId, Coupon coupon);
 
     List<UserCouponDetail> findAvailableCouponsWithDetail(long userId, FoodCategory foodCategory);
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -28,7 +28,7 @@ public class UserCouponServiceImpl implements UserCouponService {
 
     @Override
     public void registerCoupon(long userId, Coupon coupon) {
-        couponRegisterProducer.register(userId, coupon.getId(), coupon.getDuration());
+        couponRegisterProducer.register(coupon.getId(), userId, coupon.getDuration());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -4,10 +4,10 @@ import ksh.deliveryhub.common.exception.CustomException;
 import ksh.deliveryhub.common.exception.ErrorCode;
 import ksh.deliveryhub.coupon.entity.CouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
-import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
 import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
+import ksh.deliveryhub.coupon.producer.UserCouponRegisterProducer;
 import ksh.deliveryhub.coupon.repository.UserCouponRepository;
 import ksh.deliveryhub.coupon.repository.projection.UserCouponDetailProjection;
 import ksh.deliveryhub.store.entity.FoodCategory;
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -24,29 +23,17 @@ import java.util.List;
 public class UserCouponServiceImpl implements UserCouponService {
 
     private final UserCouponRepository userCouponRepository;
+    private final UserCouponRegisterProducer couponRegisterProducer;
     private final Clock clock;
 
-    @Transactional
     @Override
-    public UserCoupon registerCoupon(long userId, Coupon coupon) {
+    public void registerCoupon(long userId, Coupon coupon) {
         userCouponRepository.findByUserIdAndCouponId(userId, coupon.getId())
             .ifPresent(userCouponEntity ->
                 {throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);}
             );
 
-
-        Integer duration = coupon.getDuration();
-        LocalDate expireAt = LocalDate.now(clock).plusDays(duration);
-
-        UserCouponEntity userCouponEntity = UserCouponEntity.builder()
-            .couponStatus(UserCouponStatus.ACTIVE)
-            .userId(userId)
-            .couponId(coupon.getId())
-            .expireAt(expireAt)
-            .build();
-        userCouponRepository.save(userCouponEntity);
-
-        return UserCoupon.from(userCouponEntity);
+        couponRegisterProducer.register(userId, coupon.getId(), coupon.getDuration());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -28,11 +28,6 @@ public class UserCouponServiceImpl implements UserCouponService {
 
     @Override
     public void registerCoupon(long userId, Coupon coupon) {
-        userCouponRepository.findByUserIdAndCouponId(userId, coupon.getId())
-            .ifPresent(userCouponEntity ->
-                {throw new CustomException(ErrorCode.USER_COUPON_ALREADY_REGISTERED);}
-            );
-
         couponRegisterProducer.register(userId, coupon.getId(), coupon.getDuration());
     }
 

--- a/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/ksh/deliveryhub/coupon/service/UserCouponServiceImpl.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Clock;
 import java.util.List;
 
 @Service
@@ -24,7 +23,6 @@ public class UserCouponServiceImpl implements UserCouponService {
 
     private final UserCouponRepository userCouponRepository;
     private final UserCouponRegisterProducer couponRegisterProducer;
-    private final Clock clock;
 
     @Override
     public void registerCoupon(long userId, Coupon coupon) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,5 +13,8 @@ spring:
         format_sql: true
         default_batch_fetch_size: 1000
 
+environment:
+  KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+
 logging.level:
   org.hibernate.SQL: debug

--- a/src/test/java/ksh/deliveryhub/coupon/service/UserCouponServiceImplTest.java
+++ b/src/test/java/ksh/deliveryhub/coupon/service/UserCouponServiceImplTest.java
@@ -6,7 +6,6 @@ import ksh.deliveryhub.coupon.entity.CouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponEntity;
 import ksh.deliveryhub.coupon.entity.UserCouponStatus;
 import ksh.deliveryhub.coupon.model.Coupon;
-import ksh.deliveryhub.coupon.model.UserCoupon;
 import ksh.deliveryhub.coupon.model.UserCouponDetail;
 import ksh.deliveryhub.coupon.repository.CouponRepository;
 import ksh.deliveryhub.coupon.repository.UserCouponRepository;
@@ -69,10 +68,11 @@ class UserCouponServiceImplTest {
         LocalDate expireAt = LocalDate.of(2025, 5, 12);
 
         //when
-        UserCoupon registeredCoupon = userCouponService.registerCoupon(1L, coupon);
+        userCouponService.registerCoupon(1L, coupon);
+        Thread.sleep(10000);
 
         //then
-        UserCouponEntity userCouponEntity = userCouponRepository.findById(registeredCoupon.getId()).get();
+        UserCouponEntity userCouponEntity = userCouponRepository.findByUserIdAndCouponId(1L, 1L).get();
         assertThat(userCouponEntity.getUserId()).isEqualTo(1L);
         assertThat(userCouponEntity.getCouponId()).isEqualTo(1L);
         assertThat(userCouponEntity.getCouponStatus()).isEqualTo(ACTIVE);


### PR DESCRIPTION
# 📝 주요 구현 사항

## 🛠️ Kafka를 통한 비동기 쿠폰 저장
![선착순 쿠폰 발급 아키텍쳐](https://github.com/user-attachments/assets/6b3cd89b-71e1-4ba9-907b-02bdb80f1455)

###  기존 처리 방식

- 쿠폰 **재고 감소**와 **유저 쿠폰 저장**을 모두 **동기적으로** 처리했습니다.  
- Redisson 락을 통해 동시성 제어를 한 뒤, 모든 작업을 완료한 후 사용자에게 응답했습니다.

### 변경 사항: Kafka 기반 비동기 처리 도입

- Kafka를 도입하여 재고 감소만 처리하고,  
  **`UserCouponRegisterEvent`를 발행한 후 즉시 사용자에게 응답**하도록 변경했습니다.  
- 유저 쿠폰 저장은 Kafka **컨슈머가 비동기적으로** 처리합니다.


###  중복 발급 방지를 위한 Redis 활용

- 컨슈머는 쿠폰 저장 전에 **해당 유저가 이미 쿠폰을 발급받았는지 확인**해야 합니다.  
- 고려할만한 방안은 다음과 같이 몇가지 있습니다:
  - Redisson 락 사용 → 컨슈머가 락을 점유하게 되어 **비동기 처리의 이점이 감소합니다.**
  - DB 비관적 락 사용 → **DB 부하가 증가하고 성능이 저하됩니다.**

- 이에 대한 해결책으로 Redis를 사용합니다.
  - Redis에 **쿠폰을 발급한 유저의 ID를 Set 형태로 캐싱**합니다.
  - 저장 전에 Set에 유저 ID가 존재하는지 확인합니다.
  - 존재하지 않으면 쿠폰을 저장하고, 유저 ID를 Set에 추가합니다.

### 실패 대응: Kafka Dead Letter Topic(DLT) 구성

- 네트워크 오류나 커넥션 고갈 등의 이슈로 인해 저장에 실패할 수 있습니다.  
- 이러한 상황을 대비하여 Kafka **DLT(Dead Letter Topic)를 활용한 재시도 처리**를 구성했습니다.  
- 쿠폰은 발급 직후 바로 사용되는 경우가 드물다고 판단하여,  
  **실시간성은 일부 감수하더라도 안정성을 확보하는 방향으로 설계했습니다.**

---

# 💬 공유 사항

## 📌 TODO 리스트

- 성능 테스트를 진행했으나 정상적인 결과가 나오지 않았으며, CPU 자원 고갈 등의 문제가 원인으로 추정됩니다.
- 대안을 마련한 뒤 성능 테스트를 다시 진행해 비동기 처리의 효과를 검증할 예정입니다.

## 📌 Kafka 사용상의 미흡한 점 존재
- 선착순 쿠폰 이벤트의 높은 처리량 요구사항을 충족하기 위해 RabbitMQ 대신 Kafka를 도입하였습니다.  
- 도입 과정에서 Kafka의 학습 곡선과 운영 난이도가 제가 생각한 것보다 더 높았습니다.
- Kafka 사용에 있어 보완해야 할 부분이나 추가로 개선할 점이 있다면 피드백을 부탁드립니다.  